### PR TITLE
Fix receive buffers not being released when compiled for IP4 only (NX_DISABLE_IPV6)

### DIFF
--- a/ra/fsp/src/rm_netxduo_ether/rm_netxduo_ether.c
+++ b/ra/fsp/src/rm_netxduo_ether/rm_netxduo_ether.c
@@ -482,7 +482,9 @@ void rm_netxduo_ether_receive_packet (rm_netxduo_ether_instance_t * p_netxduo_et
                                    ((UINT) (*(p_nx_buffers[index]->nx_packet_prepend_ptr + 13)));
 
                 if ((packet_type == NX_ETHERNET_IP) ||
+#ifndef NX_DISABLE_IPV6
                     (packet_type == NX_ETHERNET_IPV6) ||
+#endif                    
                     (packet_type == NX_ETHERNET_ARP)
 #if RM_NETXDUO_ETHER_RARP_SUPPORT
                     || (packet_type == NX_ETHERNET_RARP)


### PR DESCRIPTION
When NetXDuo is compiled for IP4 only (NX_DISABLE_IPV6 set), the FSP Ethernet driver will not release the RX buffer for IPv6 packets it receives and after a short while run out of Ethernet receive buffers and the Ethernet will stop functioning. This fix makes sure, the RX buffer is released for any IPv6 packets received.
