### PR TITLE
nx_packet_length not set in rm_netxduo_ether_receive_packet()

### DIFF
--- a/ra/fsp/src/rm_netxduo_ether/rm_netxduo_ether.c
+++ b/ra/fsp/src/rm_netxduo_ether/rm_netxduo_ether.c
@@ -522,6 +522,9 @@ void rm_netxduo_ether_receive_packet (rm_netxduo_ether_instance_t * p_netxduo_et
 #endif
                         )
                     {
+                        /* Update length. */
+                        p_nx_buffers[index]->nx_packet_length = length;                        
+
                         /* Move the append ptr to the new end of data. */
                         p_nx_buffers[index]->nx_packet_append_ptr = p_nx_buffers[index]->nx_packet_prepend_ptr +
                                                                     p_nx_buffers[index]->nx_packet_length;


### PR DESCRIPTION
The `rm_netxduo_ether_receive_packet()` ISR in file `ra\fsp\src\rm_netxduo_ether\rm_netxduo_ether.c` did not set the `nx_packet_length` field and left it set a 0. Subsequent update in line  523:
```
                        p_nx_buffers[index]->nx_packet_length      -= (NX_ETHERNET_SIZE + padding);
```
subtracts from 0, resulting in an erroneous length value of `4294967280` which causes issues further upstream in NetXDuo's processing. The  `nx_packet_append_ptr` is also affected.

This PR set the nx_packet_length  value based on the received packet's length.