### PR TITLE
Remove need for floating point support from HS300X module

### DIFF
--- a/ra/fsp/src/rm_hs300x/rm_hs300x.c
+++ b/ra/fsp/src/rm_hs300x/rm_hs300x.c
@@ -279,7 +279,7 @@ fsp_err_t RM_HS300X_DataCalculate (rm_hs300x_ctrl_t * const     p_api_ctrl,
     tmp_u16 = (uint16_t)((tmp_u16 | (uint16_t) (p_raw_data->temperature[1] & RM_HS300X_MASK_TEMPERATURE_LOWER_0XFC)) >> 2);
     tmp = ((tmp_u16 * RM_HS300X_CALC_TEMP_C_VALUE_165 * 100) / RM_HS300X_CALC_STATIC_VALUE) - (RM_HS300X_CALC_TEMP_C_VALUE_40 * 100);
     p_hs300x_data->temperature.integer_part = (int16_t)(tmp / 100);
-    p_hs300x_data->temperature.decimal_part = (int16_t)(tmp & 100);
+    p_hs300x_data->temperature.decimal_part = (int16_t)(tmp % 100);
 #endif
 
     return FSP_SUCCESS;

--- a/ra/fsp/src/rm_hs300x/rm_hs300x.c
+++ b/ra/fsp/src/rm_hs300x/rm_hs300x.c
@@ -46,11 +46,11 @@
 #define RM_HS300X_DATA_STATUS_VALID                  (0x00) // Status-bit: Valid data
 
 /* Definitions for Calculation */
-#define RM_HS300X_CALC_STATIC_VALUE                  (16383.0F)
-#define RM_HS300X_CALC_HUMD_VALUE_100                (100.0F)
-#define RM_HS300X_CALC_TEMP_C_VALUE_165              (165.0F)
-#define RM_HS300X_CALC_TEMP_C_VALUE_40               (40.0F)
-#define RM_HS300X_CALC_DECIMAL_VALUE_100             (100.0F)
+#define RM_HS300X_CALC_STATIC_VALUE                  (16383)
+#define RM_HS300X_CALC_HUMD_VALUE_100                (100)
+#define RM_HS300X_CALC_TEMP_C_VALUE_165              (165)
+#define RM_HS300X_CALC_TEMP_C_VALUE_40               (40)
+#define RM_HS300X_CALC_DECIMAL_VALUE_100             (100)
 
 /* Definitions for Programming mode */
 #define RM_HS300X_PROGRAMMING_MODE_ENTER             (0xA0)
@@ -250,7 +250,7 @@ fsp_err_t RM_HS300X_DataCalculate (rm_hs300x_ctrl_t * const     p_api_ctrl,
 {
     rm_hs300x_instance_ctrl_t * p_ctrl = (rm_hs300x_instance_ctrl_t *) p_api_ctrl;
     uint8_t  status;
-    float    tmp_f   = 0.0;
+    int32_t  tmp = 0;
     uint16_t tmp_u16 = 0x0000U;
 
 #if RM_HS300X_CFG_PARAM_CHECKING_ENABLE
@@ -267,24 +267,19 @@ fsp_err_t RM_HS300X_DataCalculate (rm_hs300x_ctrl_t * const     p_api_ctrl,
     FSP_ERROR_RETURN(RM_HS300X_DATA_STATUS_VALID == status, FSP_ERR_SENSOR_INVALID_DATA);
 
     /* Relative Humidity [%RH] */
-    tmp_u16 =
-        (uint16_t) ((uint16_t) (p_raw_data->humidity[0] & RM_HS300X_MASK_HUMIDITY_UPPER_0X3F) << 8);
-    tmp_f = (float) (tmp_u16 | (uint16_t) (p_raw_data->humidity[1]));
-    tmp_f = (tmp_f * RM_HS300X_CALC_HUMD_VALUE_100) / RM_HS300X_CALC_STATIC_VALUE;
-    p_hs300x_data->humidity.integer_part = (int16_t) tmp_f;
-    p_hs300x_data->humidity.decimal_part =
-        (int16_t) ((tmp_f - (float) p_hs300x_data->humidity.integer_part) * RM_HS300X_CALC_DECIMAL_VALUE_100);
+    tmp_u16 = (uint16_t) ((uint16_t) (p_raw_data->humidity[0] & RM_HS300X_MASK_HUMIDITY_UPPER_0X3F) << 8);
+    tmp_u16 = (uint16_t)(tmp_u16 | (uint16_t) (p_raw_data->humidity[1]));
+    tmp = (tmp_u16 * RM_HS300X_CALC_HUMD_VALUE_100 * 100) / RM_HS300X_CALC_STATIC_VALUE;
+    p_hs300x_data->humidity.integer_part = (int16_t)(tmp / 100);
+    p_hs300x_data->humidity.decimal_part = (int16_t)(tmp % 100);
 
 #if RM_HS300X_CFG_DATA_BOTH_HUMIDITY_TEMPERATURE
-
     /* Temperature [Celsius] */
     tmp_u16 = (uint16_t) ((uint16_t) (p_raw_data->temperature[0]) << 8);
-    tmp_f   =
-        (float) ((tmp_u16 | (uint16_t) (p_raw_data->temperature[1] & RM_HS300X_MASK_TEMPERATURE_LOWER_0XFC)) >> 2);
-    tmp_f = ((tmp_f * RM_HS300X_CALC_TEMP_C_VALUE_165) / RM_HS300X_CALC_STATIC_VALUE) - RM_HS300X_CALC_TEMP_C_VALUE_40;
-    p_hs300x_data->temperature.integer_part = (int16_t) tmp_f;
-    p_hs300x_data->temperature.decimal_part =
-        (int16_t) ((tmp_f - (float) p_hs300x_data->temperature.integer_part) * RM_HS300X_CALC_DECIMAL_VALUE_100);
+    tmp_u16 = (uint16_t)((tmp_u16 | (uint16_t) (p_raw_data->temperature[1] & RM_HS300X_MASK_TEMPERATURE_LOWER_0XFC)) >> 2);
+    tmp = ((tmp_u16 * RM_HS300X_CALC_TEMP_C_VALUE_165 * 100) / RM_HS300X_CALC_STATIC_VALUE) - (RM_HS300X_CALC_TEMP_C_VALUE_40 * 100);
+    p_hs300x_data->temperature.integer_part = (int16_t)(tmp / 100);
+    p_hs300x_data->temperature.decimal_part = (int16_t)(tmp & 100);
 #endif
 
     return FSP_SUCCESS;


### PR DESCRIPTION
There is no need to use floating point arithmetic to extract the readings.
Using fixed point arithmetic, we can remove the need to link `__aeabi_fsub` and `__aeabi_fmul` on devices without an FPU like the RA2 series, which saves about 1.5Kb of internalRom