### PR TITLE
Fix: Use struct can_cfg_t members error_irq and rx_irq for interrupt configuration, instead of hardcoded constants.

### DIFF
--- a/ra/fsp/src/r_canfd/r_canfd.c
+++ b/ra/fsp/src/r_canfd/r_canfd.c
@@ -257,7 +257,7 @@ fsp_err_t R_CANFD_Open (can_ctrl_t * const p_api_ctrl, can_cfg_t const * const p
             R_CANFD->CFDRFCC[i] = p_global_cfg->rx_fifo_config[i];
         }
 
-        R_BSP_IrqCfgEnable(VECTOR_NUMBER_CAN_RXF, p_global_cfg->rx_fifo_ipl, NULL);
+        R_BSP_IrqCfgEnable(p_cfg->rx_irq, p_global_cfg->rx_fifo_ipl, NULL);
 
         /* Set global error interrupts */
         R_CANFD->CFDGCTR = p_global_cfg->global_interrupts;
@@ -266,7 +266,7 @@ fsp_err_t R_CANFD_Open (can_ctrl_t * const p_api_ctrl, can_cfg_t const * const p
     if (CANFD_CFG_GLOBAL_ERROR_CH == channel)
     {
         /* Configure global error interrupt */
-        R_BSP_IrqCfgEnable(VECTOR_NUMBER_CAN_GLERR, p_global_cfg->global_err_ipl, NULL);
+        R_BSP_IrqCfgEnable(p_cfg->error_irq, p_global_cfg->global_err_ipl, NULL);
     }
 
     /* Track ctrl struct */


### PR DESCRIPTION
The struct can_cfg_t (defined in r_can_api.h) contains entries for storing error_irq and rx_irq.

```C
typedef struct st_can_cfg
{
    /* CAN generic configuration */
    uint32_t               channel;                    ///< CAN channel.
    can_bit_timing_cfg_t * p_bit_timing;               ///< CAN bit timing.

    /* Configuration for CAN Event processing */
    void (* p_callback)(can_callback_args_t * p_args); ///< Pointer to callback function
    void const * p_context;                            ///< User defined callback context.

    /* Pointer to CAN peripheral specific configuration */
    void const * p_extend;                             ///< CAN hardware dependent configuration
    uint8_t      ipl;                                  ///< Error/Transmit/Receive interrupt priority
    IRQn_Type    error_irq;                            ///< Error IRQ number
    IRQn_Type    rx_irq;                               ///< Receive IRQ number
    IRQn_Type    tx_irq;                               ///< Transmit IRQ number
} can_cfg_t;
```

Unfortunately those entries are ignored and instead hard-coded values that are generated within e2studio are used. This becomes a problem as soon as one wants to step out of the e2studio provided framework of code generation.

This is i.e. not an issue within the SPI peripheral, which does not contain hard coded vector constants.

CC @facchinm .