### PR TITLE
Update rm_freertos_plus_fat.c

### DIFF
--- a/ra/fsp/src/rm_freertos_plus_fat/rm_freertos_plus_fat.c
+++ b/ra/fsp/src/rm_freertos_plus_fat/rm_freertos_plus_fat.c
@@ -389,7 +389,7 @@ int32_t rm_freertos_plus_fat_read (uint8_t * p_data, uint32_t sector, uint32_t n
 
     if (FSP_SUCCESS != err)
     {
-        return FF_ERR_IOMAN_DRIVER_FATAL_ERROR;
+        return (int32_t) (FF_ERR_IOMAN_DRIVER_FATAL_ERROR | FF_ERRFLAG);
     }
 
     lReturnCode = FF_ERR_NONE;
@@ -434,7 +434,7 @@ int32_t rm_freertos_plus_fat_write (uint8_t * p_data, uint32_t sector, uint32_t 
 
     if (FSP_SUCCESS != err)
     {
-        return FF_ERR_IOMAN_DRIVER_FATAL_ERROR;
+        return (int32_t) (FF_ERR_IOMAN_DRIVER_FATAL_ERROR | FF_ERRFLAG);
     }
 
     lReturnCode = FF_ERR_NONE;


### PR DESCRIPTION
Fix return error value of rm_freertos_plus_fat_read() and rm_freertos_plus_fat_write() raising the corresponding flag FF_ERRFLAG