### PR TITLE
Stop trng after generation to save power

### DIFF
--- a/ra/fsp/src/r_sce/trng/r_sce_trng.c
+++ b/ra/fsp/src/r_sce/trng/r_sce_trng.c
@@ -51,5 +51,9 @@ fsp_err_t HW_SCE_RNG_Read (uint32_t * OutData_Text) {
         *ptmp++ = R_TRNG->TRNGSDR;
     }
 
+    /* Clear SGCEN bit and SGSTART bit */
+    R_TRNG->TRNGSCR0_b.SGCEN   = 0;
+    R_TRNG->TRNGSCR0_b.SGSTART = 0;
+
     return FSP_SUCCESS;
 }


### PR DESCRIPTION

We have noticed that after reading a random number from the TRNG, the sleep(Standby) current from our RA2E1 board jumps from ~8uA to ~370uA.
I couldn't find any documentation regarding the TRNG, so I am not sure if `SGSTART` needs to be cleared, but setting both seems to have fixed the issue we were seeing.

## Details:
FSP 4.1.0 (I have adapted the PR for the latest commit in master)
R7FA2E1A93CFJ#AA0

## Code to reproduce:
```C
   uint8_t p = 0;
   while (1)
   {
      (void)RM_TINCYRYPT_PORT_TRNG_Read(&p, sizeof(uint8_t));
      (void)g_lpm0.p_api->lowPowerModeEnter(g_lpm0.p_ctrl);
   }
```