### PR TITLE
add mising gcc warnings push

### DIFF
--- a/ra/fsp/inc/api/bsp_api.h
+++ b/ra/fsp/inc/api/bsp_api.h
@@ -35,6 +35,7 @@
 
 /* CMSIS-CORE currently generates 2 warnings when compiling with GCC. One in core_cmInstr.h and one in core_cm4_simd.h.
  * We are not modifying these files so we will ignore these warnings temporarily. */
+ #pragma GCC diagnostic push
  #pragma GCC diagnostic ignored "-Wconversion"
  #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif


### PR DESCRIPTION
Fix missing gcc dianostic push. Before making changes to GCC warnings, we should always push first then pop afterwards. `bsp_api.h` pop the diagnostic but doesn't push and mess up with the higher level warnings suppression e.g 'bsp_api.h' have a warnings when compiling with "-Wstrict-prototype" but application cannot suppress it using prama

```C
#ifdef __GNUC__
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wstrict-prototypes"
#endif

#include "bsp_api.h"

#ifdef __GNUC__
#pragma GCC diagnostic pop
#endif
```

Since bsp_api.h will pop --> restore the diagnostic before "-Wstrict-prototypes" is ignored i.e it discards the application pragma.
 