### PR TITLE
GPT: Fix prototype of function (explicit empty argument list)

### DIFF
--- a/ra/fsp/inc/instances/r_gpt.h
+++ b/ra/fsp/inc/instances/r_gpt.h
@@ -434,7 +434,7 @@ fsp_err_t R_GPT_CallbackSet(timer_ctrl_t * const          p_api_ctrl,
                             void const * const            p_context,
                             timer_callback_args_t * const p_callback_memory);
 fsp_err_t R_GPT_Close(timer_ctrl_t * const p_ctrl);
-fsp_err_t R_GPT_PwmOutputDelayInitialize();
+fsp_err_t R_GPT_PwmOutputDelayInitialize(void);
 
 /*******************************************************************************************************************//**
  * @} (end defgroup GPT)

--- a/ra/fsp/src/r_gpt/r_gpt.c
+++ b/ra/fsp/src/r_gpt/r_gpt.c
@@ -1055,7 +1055,7 @@ fsp_err_t R_GPT_Close (timer_ctrl_t * const p_ctrl)
  * @retval FSP_ERR_INVALID_STATE       The source clock frequnecy is out of the required range for the PDG.
  * @retval FSP_ERR_UNSUPPORTED         This feature is not supported.
  **********************************************************************************************************************/
-fsp_err_t R_GPT_PwmOutputDelayInitialize ()
+fsp_err_t R_GPT_PwmOutputDelayInitialize (void)
 {
 #if 0U != BSP_FEATURE_GPT_ODC_VALID_CHANNEL_MASK && GPT_CFG_OUTPUT_SUPPORT_ENABLE
  #if BSP_FEATURE_GPT_ODC_FRANGE_FREQ_MIN > 0 || GPT_CFG_PARAM_CHECKING_ENABLE


### PR DESCRIPTION
The function `R_GPT_PwmOutputDelayInitialize` generates an compiler error (`no prototype`) when the "Require prototype" option is active in IAR EWARM.

The reason is that the prototype and function definition is missing void as argument.