### PR TITLE
Fix misspell findings & add a GitHub action for misspell

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -1,0 +1,20 @@
+name: misspell
+on: push
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: fsp-'${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run misspell (findings may not increase)
+        if: always()
+        run: |
+            curl -L -o ./install-misspell.sh https://git.io/misspell
+            sh ./install-misspell.sh
+            bin/misspell -i mosquitto .

--- a/ra/fsp/inc/api/r_cec_api.h
+++ b/ra/fsp/inc/api/r_cec_api.h
@@ -61,7 +61,7 @@ typedef enum e_cec_addr
 {
     CEC_ADDR_TV                 = 0U,  ///< CEC Address for TV
     CEC_ADDR_RECORDING_DEVICE_1 = 1U,  ///< CEC Address for Recording Device 1
-    CEC_ADDR_RECORDING_DEVICE_2 = 2U,  ///< CEC Address for Recording Devide 2
+    CEC_ADDR_RECORDING_DEVICE_2 = 2U,  ///< CEC Address for Recording Divide 2
     CEC_ADDR_TUNER_1            = 3U,  ///< CEC Address for Tuner 1
     CEC_ADDR_PLAYBACK_DEVICE_1  = 4U,  ///< CEC Address for Playback Device 1
     CEC_ADDR_AUDIO_SYSTEM       = 5U,  ///< CEC Address for Audio System

--- a/ra/fsp/inc/api/r_i3c_api.h
+++ b/ra/fsp/inc/api/r_i3c_api.h
@@ -155,7 +155,7 @@ typedef enum e_i3c_type
 /** Identifies the protocol for transferring data with the device on the bus. */
 typedef enum e_i3c_device_protocol
 {
-    I3C_DEVICE_PROTOCOL_I2C,           ///< Transfers will use legacy I2C protocal with open-drain output at a reduced baudrate.
+    I3C_DEVICE_PROTOCOL_I2C,           ///< Transfers will use legacy I2C protocol with open-drain output at a reduced baudrate.
     I3C_DEVICE_PROTOCOL_I3C,           ///< Transfers will use I3C SDR mode.
 } i3c_device_protocol_t;
 
@@ -442,7 +442,7 @@ typedef struct st_i3c_api
     /**
      * In master mode: Start a write transfer. When the transfer is completed send a stop condition or a repeated-start.
      * In slave mode:  Set the write buffer and configure the number of bytes that will be transferred before the the transfer
-     *                 is ended by the slave via the 'T' bit or by the master issueing a stop condition.
+     *                 is ended by the slave via the 'T' bit or by the master issuing a stop condition.
      *
      * @par Implemented as
      * - @ref R_I3C_Write()

--- a/ra/fsp/inc/api/r_ioport_api.h
+++ b/ra/fsp/inc/api/r_ioport_api.h
@@ -212,7 +212,7 @@ typedef enum e_ioport_cfg_options
     IOPORT_CFG_PULLUP_ENABLE         = 0x00000010, ///< Enables the pin's internal pull-up
     IOPORT_CFG_PIM_TTL               = 0x00000020, ///< Enables the pin's input mode
     IOPORT_CFG_NMOS_ENABLE           = 0x00000040, ///< Enables the pin's NMOS open-drain output
-    IOPORT_CFG_PMOS_ENABLE           = 0x00000080, ///< Enables the pin's PMOS open-drain ouput
+    IOPORT_CFG_PMOS_ENABLE           = 0x00000080, ///< Enables the pin's PMOS open-drain output
     IOPORT_CFG_DRIVE_MID             = 0x00000400, ///< Sets pin drive output to medium
     IOPORT_CFG_DRIVE_HS_HIGH         = 0x00000800, ///< Sets pin drive output to high along with supporting high speed
     IOPORT_CFG_DRIVE_MID_IIC         = 0x00000C00, ///< Sets pin to drive output needed for IIC on a 20mA port

--- a/ra/fsp/inc/api/r_keymatrix_api.h
+++ b/ra/fsp/inc/api/r_keymatrix_api.h
@@ -69,7 +69,7 @@ typedef enum e_keymatrix_trigger
 } keymatrix_trigger_t;
 
 /** Callback function parameter data */
-typedef struct st_keymatrix_calback_args
+typedef struct st_keymatrix_callback_args
 {
     void const * p_context;            ///< Holder for user data. Set in @ref keymatrix_api_t::open function in @ref keymatrix_cfg_t.
 

--- a/ra/fsp/inc/api/r_ptp_api.h
+++ b/ra/fsp/inc/api/r_ptp_api.h
@@ -254,7 +254,7 @@ typedef enum e_ptp_event
     PTP_EVENT_SYNC_ACQUIRED                = 0x80, ///< The local clock is synchronized to the master clock.
     PTP_EVENT_SYNC_LOST                    = 0x81, ///< The local clock is not synchronized to the master clcok.
     PTP_EVENT_SYNC_MESSAGE_TIMEOUT         = 0x83, ///< A sync message has not been received for the configured time.
-    PTP_EVENT_WORST10_ACQUIRED             = 0x84, ///< Gradient worst10 values has been calcualted.
+    PTP_EVENT_WORST10_ACQUIRED             = 0x84, ///< Gradient worst10 values has been calculated.
     PTP_EVENT_OFFSET_FROM_MASTER_UPDATED   = 0x00, ///< The offset from the master clock has been updated.
     PTP_EVENT_LOG_MESSAGE_INT_CHANGED      = 0x01, ///< The message interval was changed.
     PTP_EVENT_MEAN_PATH_DELAY_UPDATED      = 0x02, ///< The mean path delay has been updated.
@@ -274,8 +274,8 @@ typedef enum e_ptp_event
 /** The Ethernet PHY interface type. */
 typedef enum e_ptp_ethernet_phy_interface
 {
-    PTP_ETHERNET_PHY_INTERFACE_MII,    ///< Media-independant interface.
-    PTP_ETHERNET_PHY_INTERFACE_RMII,   ///< Reduced media-independant interface.
+    PTP_ETHERNET_PHY_INTERFACE_MII,    ///< Media-independent interface.
+    PTP_ETHERNET_PHY_INTERFACE_RMII,   ///< Reduced media-independent interface.
 } ptp_ethernet_phy_interface_t;
 
 /**

--- a/ra/fsp/inc/api/r_three_phase_api.h
+++ b/ra/fsp/inc/api/r_three_phase_api.h
@@ -78,14 +78,14 @@ typedef struct st_three_phase_duty_cycle
     /**
      * Duty cycle.
      * Note: When the GPT instances are configured in TIMER_MODE_TRIANGLE_WAVE_ASYMMETRIC_PWM_MODE3,
-     *       this value sets the duty cycle count that is transfered to GTCCRA/B at the trough.
+     *       this value sets the duty cycle count that is transferred to GTCCRA/B at the trough.
      */
     uint32_t duty[3];
 
     /**
      * Double-buffer for duty cycle values.
      * Note: When the GPT instances are configured in TIMER_MODE_TRIANGLE_WAVE_ASYMMETRIC_PWM_MODE3,
-     *       this value sets the duty cycle count that is transfered to GTCCRA/B at the crest.
+     *       this value sets the duty cycle count that is transferred to GTCCRA/B at the crest.
      */
     uint32_t duty_buffer[3];
 } three_phase_duty_cycle_t;

--- a/ra/fsp/inc/api/r_usb_basic_api.h
+++ b/ra/fsp/inc/api/r_usb_basic_api.h
@@ -395,7 +395,7 @@ typedef struct st_usb_cfg
     uint8_t                     module_number;      ///< USB module number (USB_IP0/USB_IP1)
     usb_class_t                 type;               ///< USB device class etc
     usb_descriptor_t          * p_usb_reg;          ///< Pointer to the usb_decriptor_t structure area
-    usb_compliance_cb_t       * usb_complience_cb;
+    usb_compliance_cb_t       * usb_compliance_cb;
     IRQn_Type                   irq;                ///< USBI dedicated interrupt number storage variable.
     IRQn_Type                   irq_r;              ///< USBR dedicated interrupt number storage variable.
     IRQn_Type                   irq_d0;             ///< FS D0FIFO dedicated interrupt number storage variable.

--- a/ra/fsp/inc/api/rm_ble_mesh_network_api.h
+++ b/ra/fsp/inc/api/rm_ble_mesh_network_api.h
@@ -186,7 +186,7 @@ typedef  enum e_rm_ble_mesh_network_event
     RM_BLE_MESH_NETWORK_EVENT_PROXY_STATUS = 0x02,
 
     /** GATT Proxy Event - Receive */
-    RM_BLE_MESH_NETWORK_EVENT_RECIEVE = 0x03,
+    RM_BLE_MESH_NETWORK_EVENT_RECEIVE = 0x03,
 
     /** GATT Proxy Event - TX queue empty */
     RM_BLE_MESH_NETWORK_EVENT_TX_QUEUE_EMPTY = 0x04,

--- a/ra/fsp/inc/api/rm_comms_api.h
+++ b/ra/fsp/inc/api/rm_comms_api.h
@@ -20,7 +20,7 @@
 
 /*******************************************************************************************************************//**
  * @ingroup RENESAS_INTERFACES
- * @defgroup RM_COMMS_API Communicatons Middleware Interface
+ * @defgroup RM_COMMS_API Communications Middleware Interface
  * @brief Interface for Communications Middleware functions.
  *
  * @section RM_COMMS_API_Summary Summary

--- a/ra/fsp/inc/api/rm_motor_api.h
+++ b/ra/fsp/inc/api/rm_motor_api.h
@@ -196,7 +196,7 @@ typedef struct st_motor_api
      * - @ref RM_MOTOR_INDUCTION_ErrorSet()
      *
      * @param[in]  p_ctrl       Pointer to control structure.
-     * @param[in]  error        Happend error code
+     * @param[in]  error        Happened error code
      */
     fsp_err_t (* errorSet)(motor_ctrl_t * const p_ctrl, motor_error_t const error);
 
@@ -280,7 +280,7 @@ typedef struct st_motor_api
      * - @ref RM_MOTOR_INDUCTION_ErrorCheck()
      *
      * @param[in]  p_ctrl       Pointer to control structure.
-     * @param[out] p_error      Pointer to get occured error
+     * @param[out] p_error      Pointer to get occurred error
      */
     fsp_err_t (* errorCheck)(motor_ctrl_t * const p_ctrl, uint16_t * const p_error);
 

--- a/ra/fsp/inc/api/rm_motor_position_api.h
+++ b/ra/fsp/inc/api/rm_motor_position_api.h
@@ -134,7 +134,7 @@ typedef struct st_motor_position_api
      * - @ref RM_MOTOR_POSITION_PositionReferenceSet()
      *
      * @param[in]  p_ctrl                 Pointer to control structure.
-     * @param[in]  position_refernce_deg  Position reference [degree]
+     * @param[in]  position_references_deg  Position reference [degree]
      */
     fsp_err_t (* positionReferenceSet)(motor_position_ctrl_t * const p_ctrl, int16_t const position_reference_deg);
 

--- a/ra/fsp/inc/api/rm_motor_speed_api.h
+++ b/ra/fsp/inc/api/rm_motor_speed_api.h
@@ -194,7 +194,7 @@ typedef struct st_motor_speed_api
      * - @ref RM_MOTOR_SPEED_SpeedReferenceSet()
      *
      * @param[in]  p_ctrl              Pointer to control structure.
-     * @param[in]  speed_refernce_rpm  Speed reference [rpm]
+     * @param[in]  speed_references_rpm  Speed reference [rpm]
      */
     fsp_err_t (* speedReferenceSet)(motor_speed_ctrl_t * const p_ctrl, float const speed_reference_rpm);
 

--- a/ra/fsp/inc/api/rm_rai_data_shipper_api.h
+++ b/ra/fsp/inc/api/rm_rai_data_shipper_api.h
@@ -63,7 +63,7 @@ typedef struct st_rai_data_shipper_callback_args
     void const     * p_context;        ///< Pointer to the user-provided context
 } rai_data_shipper_callback_args_t;
 
-/** Data Shipper write funciton parameter structure */
+/** Data Shipper write function parameter structure */
 typedef struct st_rai_data_shipper_write_params
 {
     uint16_t  events;                                   ///< Events

--- a/ra/fsp/inc/api/rm_wifi_api.h
+++ b/ra/fsp/inc/api/rm_wifi_api.h
@@ -427,7 +427,7 @@ WIFIReturnCode_t WIFI_Off(void);
  *
  * The Wi-Fi should stay connected when the same Access Point it is currently connected to
  * is specified. Otherwise, the Wi-Fi should disconnect and connect to the new Access Point
- * specified. If the new Access Point specifed has invalid parameters, then the Wi-Fi should be
+ * specified. If the new Access Point specified has invalid parameters, then the Wi-Fi should be
  * disconnected.
  *
  * @param[in] pxNetworkParams Configuration to join AP.

--- a/ra/fsp/inc/instances/r_acmphs.h
+++ b/ra/fsp/inc/instances/r_acmphs.h
@@ -70,7 +70,7 @@ typedef struct
 {
     acmphs_input_t     input_voltage;
     acmphs_reference_t reference_voltage;
-    uint32_t           maximum_status_retries; // Maximum number of status retries alowed
+    uint32_t           maximum_status_retries; // Maximum number of status retries allowed
 } r_acmphs_extended_cfg_t;
 
 /* Channel instance control block. DO NOT INITIALIZE.  Initialization occurs in @ref comparator_api_t::open. */
@@ -79,7 +79,7 @@ typedef struct st_acmphs_instance_ctrl
     uint32_t                 open;                   // Used to determine if channel control block is in use
     const comparator_cfg_t * p_cfg;                  // Pointer to initial configurations
     R_ACMPHS0_Type         * p_reg;                  // Pointer to register base address
-    uint32_t                 maximum_status_retries; // Maximum number of status retries alowed
+    uint32_t                 maximum_status_retries; // Maximum number of status retries allowed
 } acmphs_instance_ctrl_t;
 
 /***********************************************************************************************************************

--- a/ra/fsp/inc/instances/r_adc_b.h
+++ b/ra/fsp/inc/instances/r_adc_b.h
@@ -442,7 +442,7 @@ typedef struct st_adc_b_virtual_channel_cfg
 
     union
     {
-        uint32_t channel_control_b;              ///< A/D converison data operation control b
+        uint32_t channel_control_b;              ///< A/D conversions data operation control b
         struct
         {
             uint32_t addition_average_mode  : 2; ///< Addition/Averaging mode selection
@@ -489,7 +489,7 @@ typedef struct st_adc_b_group_cfg
     adc_b_virtual_channel_cfg_t ** p_virtual_channels;     ///< Pointer to virtual channel configuration array of size virtual_channel_count
 } adc_b_group_cfg_t;
 
-/** ADC Scan Group configuraiton */
+/** ADC Scan Group configuration */
 typedef struct st_adc_b_scan_cfg
 {
 /* The ADC operates on scan groups.

--- a/ra/fsp/inc/instances/r_canfd.h
+++ b/ra/fsp/inc/instances/r_canfd.h
@@ -298,7 +298,7 @@ typedef struct st_canfd_instance_ctrl
     can_operation_mode_t operation_mode;        // Can operation mode.
     can_test_mode_t      test_mode;             // Can operation mode.
 #if BSP_TZ_SECURE_BUILD
-    bool callback_is_secure;                    // If the callback is in non-secure memory then a security state transistion is required to call p_callback (BLXNS)
+    bool callback_is_secure;                    // If the callback is in non-secure memory then a security state transition is required to call p_callback (BLXNS)
 #endif
     void (* p_callback)(can_callback_args_t *); // Pointer to callback
     can_callback_args_t * p_callback_memory;    // Pointer to optional callback argument memory

--- a/ra/fsp/inc/instances/r_dmac.h
+++ b/ra/fsp/inc/instances/r_dmac.h
@@ -48,7 +48,7 @@ FSP_HEADER
 /** Max number of transfers per block in TRANSFER_MODE_BLOCK */
 #define DMAC_MAX_BLOCK_TRANSFER_LENGTH     (0x400)
 
-/** Max configurable number of repeats to trasnfer in TRANSFER_MODE_REPEAT */
+/** Max configurable number of repeats to transfer in TRANSFER_MODE_REPEAT */
 #define DMAC_MAX_REPEAT_COUNT              (0x10000)
 
 /** Max configurable number of blocks to transfer in TRANSFER_MODE_BLOCK */

--- a/ra/fsp/inc/instances/r_glcdc.h
+++ b/ra/fsp/inc/instances/r_glcdc.h
@@ -90,7 +90,7 @@ typedef enum e_glcdc_tcon_pin
 } glcdc_tcon_pin_t;
 
 /** Bus Arbitration setting */
-typedef enum e_glcdc_bus_arbitraion
+typedef enum e_glcdc_bus_arbitration
 {
     GLCDC_BUS_ARBITRATION_ROUNDROBIN,  ///< Round robin
     GLCDC_BUS_ARBITRATION_FIX_PRIORITY ///< Fixed

--- a/ra/fsp/inc/instances/r_sci_b_uart.h
+++ b/ra/fsp/inc/instances/r_sci_b_uart.h
@@ -134,7 +134,7 @@ typedef enum e_sci_b_uart_rs485_de_polarity
     SCI_B_UART_RS485_DE_POLARITY_LOW  = 1, ///< The DE signal is low when a write transfer is in progress.
 } sci_b_uart_rs485_de_polarity_t;
 
-/** Register settings to acheive a desired baud rate and modulation duty. */
+/** Register settings to achieve a desired baud rate and modulation duty. */
 typedef struct st_sci_b_baud_setting_t
 {
     union

--- a/ra/fsp/inc/instances/r_sci_uart.h
+++ b/ra/fsp/inc/instances/r_sci_uart.h
@@ -134,7 +134,7 @@ typedef enum e_sci_uart_rs485_de_polarity
     SCI_UART_RS485_DE_POLARITY_LOW  = 1, ///< The DE signal is low when a write transfer is in progress.
 } sci_uart_rs485_de_polarity_t;
 
-/** Register settings to acheive a desired baud rate and modulation duty. */
+/** Register settings to achieve a desired baud rate and modulation duty. */
 typedef struct st_baud_setting_t
 {
     union

--- a/ra/fsp/inc/instances/r_sdhi.h
+++ b/ra/fsp/inc/instances/r_sdhi.h
@@ -68,7 +68,7 @@ typedef union
         uint32_t reserved_5         : 3;
         uint32_t card_dat3_removed  : 1; // < card removal detected by dat3 pin
         uint32_t card_dat3_inserted : 1; // < card inserion detected by dat3 pin
-        uint32_t reservered_10      : 6;
+        uint32_t reserved_10      : 6;
         uint32_t cmd_err            : 1; // < command error
         uint32_t crc_err            : 1; // < crc error
         uint32_t end_err            : 1; // < end bit error

--- a/ra/fsp/inc/instances/rm_mesh_sensor_clt.h
+++ b/ra/fsp/inc/instances/rm_mesh_sensor_clt.h
@@ -267,7 +267,7 @@ typedef struct st_rm_mesh_sensor_cadence_status_info
 
     /**
      * APPLICATION NOTE:
-     * The Current Sensor Server Model implementation does not inherantly
+     * The Current Sensor Server Model implementation does not inherently
      * check for the time interval between two consecutive status messages.
      * The application layer which manages the data for the Sensor Server
      * Model holds the responsibility for interleaving consecutive status

--- a/ra/fsp/inc/instances/rm_mesh_sensor_srv.h
+++ b/ra/fsp/inc/instances/rm_mesh_sensor_srv.h
@@ -146,7 +146,7 @@ typedef struct st_rm_mesh_sensor_srv_cadence_info
 
     /**
      * APPLICATION NOTE:
-     * The Current Sensor Server Model implementation does not inherantly
+     * The Current Sensor Server Model implementation does not inherently
      * check for the time interval between two consecutive status messages.
      * The application layer which manages the data for the Sensor Server
      * Model holds the responsibility for interleaving consecutive status

--- a/ra/fsp/inc/instances/rm_motor_120_control_sensorless.h
+++ b/ra/fsp/inc/instances/rm_motor_120_control_sensorless.h
@@ -50,7 +50,7 @@ FSP_HEADER
 /** Draw in a initial position */
 typedef enum e_motor_120_control_sensorless_draw_in_position
 {
-    MOTOR_120_CONTROL_SENSORLESS_DRAW_IN_POSITION_INIT     = 0, ///< Inital parameter
+    MOTOR_120_CONTROL_SENSORLESS_DRAW_IN_POSITION_INIT     = 0, ///< Initial parameter
     MOTOR_120_CONTROL_SENSORLESS_DRAW_IN_POSITION_1ST_TIME = 1, ///< Draw in a initial position of the 1st time
     MOTOR_120_CONTROL_SENSORLESS_DRAW_IN_POSITION_2ND_TIME = 2, ///< Draw in a initial position of the 2nd time
 } motor_120_control_sensorless_draw_in_position_t;
@@ -58,7 +58,7 @@ typedef enum e_motor_120_control_sensorless_draw_in_position
 /** Pattern change */
 typedef enum e_motor_120_sensorless_pattern_change_flag
 {
-    MOTOR_120_CONTROL_SENSORLESS_PATTERN_CHANGE_FLAG_CLEAR = 0, ///< Inital parameter
+    MOTOR_120_CONTROL_SENSORLESS_PATTERN_CHANGE_FLAG_CLEAR = 0, ///< Initial parameter
     MOTOR_120_CONTROL_SENSORLESS_PATTERN_CHANGE_FLAG_SET   = 1, ///< Voltage pattern change
 } motor_120_control_sensorless_pattern_change_flag_t;
 

--- a/ra/fsp/inc/instances/rm_motor_120_driver.h
+++ b/ra/fsp/inc/instances/rm_motor_120_driver.h
@@ -151,7 +151,7 @@ typedef struct st_motor_120_driver_instance_ctrl
     uint32_t u4_gtiocb_periheral_low_cfg;                    ///< I/O port "Low" config for gtioca periheral functions
     uint32_t u4_gtiocb_periheral_high_cfg;                   ///< I/O port "High" config for gtioca periheral functions
 
-    motor_120_driver_modulation_t  st_modulation;            ///< Modulation paramter
+    motor_120_driver_modulation_t  st_modulation;            ///< Modulation parameter
     motor_120_driver_cfg_t const * p_cfg;                    ///< Pointer of configuration structure
 
     /* For ADC callback */

--- a/ra/fsp/inc/instances/rm_motor_driver.h
+++ b/ra/fsp/inc/instances/rm_motor_driver.h
@@ -49,7 +49,7 @@ FSP_HEADER
 typedef enum e_motor_driver_select_adc_instance
 {
     MOTOR_DRIVER_SELECT_ADC_INSTANCE_FIRST = 0, ///< Use first ADC instance
-    MOTOR_DRIVER_SELECT_ADC_INSTANCE_SECOND,    ///< Use second ADC instanse
+    MOTOR_DRIVER_SELECT_ADC_INSTANCE_SECOND,    ///< Use second ADC instances
 } motor_driver_select_adc_instance_t;
 
 /* Modulation type selection */

--- a/ra/fsp/inc/instances/rm_motor_inertia_estimate.h
+++ b/ra/fsp/inc/instances/rm_motor_inertia_estimate.h
@@ -88,7 +88,7 @@ typedef struct st_motor_inertia_estimate_instance_ctrl
     motor_inertia_estimate_mode_t       mode;            ///< Internal mode
     uint8_t u1_mode_count;                               ///< Use to manage internal mode
     motor_inertia_estimate_period_t speed_period;        ///< Measure period
-    motor_inertia_estimate_period_t speed_period_buffer; ///< Buffer of measure period to be reffered by current cyclic
+    motor_inertia_estimate_period_t speed_period_buffer; ///< Buffer of measure period to be referred by current cyclic
 
     uint32_t u4_measure_count;                           ///< Counter for speed control cycle
     uint32_t u4_wait_count;                              ///< Counter to wait change mode timing
@@ -99,7 +99,7 @@ typedef struct st_motor_inertia_estimate_instance_ctrl
     float   f_iq_ad;                                     ///< q-axis current [A]
     float   f_summary_iq_ad;                             ///< Summary of q-axis current
     float   f_position_mode_time;                        ///< Summary of speed control period to judge the timing
-    float   f_position_dt_time_sec;                      ///< Differencial time of move
+    float   f_position_dt_time_sec;                      ///< Differential time of move
 
     int16_t s2_position_reference_degree;                ///< Position reference [degree]
 

--- a/ra/fsp/inc/instances/rm_motor_position.h
+++ b/ra/fsp/inc/instances/rm_motor_position.h
@@ -133,7 +133,7 @@ typedef struct st_motor_position_ipd_design_parameter
 /*********************************/
 /*     For Position Profiling    */
 /*********************************/
-typedef struct st_motor_positon_profiling
+typedef struct st_motor_position_profiling
 {
     uint8_t  u1_state_pos_pf;          ///< position profile status
     uint8_t  u1_pos_ref_mode;          ///< position reference mode

--- a/ra/fsp/inc/instances/rm_motor_return_origin.h
+++ b/ra/fsp/inc/instances/rm_motor_return_origin.h
@@ -88,7 +88,7 @@ typedef struct st_motor_return_origin_instance_ctrl
     float  f_current_speed;                      ///< Current speed
     float  f_origin_position_angle_degree;       ///< Searched origin position [degree]
     float  f_search_speed;                       ///< Speed to search origin position [rad / sampling time]
-    float  f_accel_speed;                        ///< Speed accelaration
+    float  f_accel_speed;                        ///< Speed acceleration
     float  f_position_reference_degree;          ///< Position reference [degree]
 
     motor_return_origin_pushing_t st_pushing;    ///< Variables for pushing

--- a/ra/fsp/inc/instances/rm_motor_sense_hall.h
+++ b/ra/fsp/inc/instances/rm_motor_sense_hall.h
@@ -55,7 +55,7 @@ typedef enum e_motor_sense_hall_signal_status
     MOTOR_SENSE_HALL_SIGNAL_STATUS_CAPTURED = 0, ///< Hall signal is captured.
 } motor_sense_hall_signal_status_t;
 
-/** This stucture is provided to receive speed information. */
+/** This structure is provided to receive speed information. */
 typedef struct st_motor_sense_hall_input
 {
     float f4_ref_speed_rad_ctrl;       ///< Speed Reference [rad/sec]
@@ -71,7 +71,7 @@ typedef struct st_motor_sense_hall_extended_cfg
     uint8_t u1_hall_pattern[MOTOR_SENSE_HALL_SPEED_COUNTS + 1]; ///< The order of hall signal pattern
 
     float f_pwm_carrier_freq;                                   ///< PWM carrier frequency        20.0kHz
-    float f_angle_correct;                                      ///< Coefficent to correct angle  0.4
+    float f_angle_correct;                                      ///< Coefficient to correct angle  0.4
 
     uint8_t  u1_trigger_hall_signal_count;                      ///< Rotation counts to wait the stability
     float    f4_target_pseudo_speed_rad;                        ///< Target value for pseudo speed estimates [radian/second]

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2A1AB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2A1AB.h
@@ -4056,9 +4056,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2E1A9.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2E1A9.h
@@ -3470,9 +3470,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2E2A7.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2E2A7.h
@@ -2696,9 +2696,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2L1AB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA2L1AB.h
@@ -4033,9 +4033,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4E10D.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4E10D.h
@@ -3953,9 +3953,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -7775,7 +7775,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4E2B9.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4E2B9.h
@@ -4393,9 +4393,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M1AB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M1AB.h
@@ -3980,9 +3980,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M2AD.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M2AD.h
@@ -4196,9 +4196,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -8074,7 +8074,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M3AF.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4M3AF.h
@@ -4196,9 +4196,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -8074,7 +8074,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4T1BB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4T1BB.h
@@ -4471,9 +4471,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4W1AD.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA4W1AD.h
@@ -3980,9 +3980,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6E10F.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6E10F.h
@@ -3953,9 +3953,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -8503,7 +8503,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6E2BB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6E2BB.h
@@ -4393,9 +4393,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -9408,7 +9408,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M1AD.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M1AD.h
@@ -3934,9 +3934,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -7982,7 +7982,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M2AF.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M2AF.h
@@ -3934,9 +3934,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -9963,7 +9963,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M3AH.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M3AH.h
@@ -4844,9 +4844,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -12621,7 +12621,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M4AF.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M4AF.h
@@ -4231,9 +4231,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -8837,7 +8837,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M5BH.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M5BH.h
@@ -5356,9 +5356,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -11099,7 +11099,7 @@ typedef struct                         /*!< (@ 0x64000000) R_QSPI Structure     
         {
             uint32_t                : 26;
             __IOM uint32_t QSPI_EXT : 6; /*!< [31..26] BANK Switching AddressWhen accessing from 0x6000_0000
-                                          *   to 0x63FF_FFFF, Addres bus is Set QSPI_EXT[5:0] to high-order
+                                          *   to 0x63FF_FFFF, Address bus is Set QSPI_EXT[5:0] to high-order
                                           *   6bits of SHADDR[31:0]NOTE: Setting 6'h3F is prihibited.                   */
         } SFMCNT1_b;
     };

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T1AD.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T1AD.h
@@ -3468,9 +3468,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T2BD.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T2BD.h
@@ -4523,9 +4523,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */
@@ -14453,7 +14453,7 @@ typedef struct                         /*!< (@ 0x40170000) R_ADC_B0 Structure   
 
     union
     {
-        __IOM uint32_t ADPGAMONCR;      /*!< (@ 0x00000300) Programable Gain Amp Monitor Output Control Register       */
+        __IOM uint32_t ADPGAMONCR;      /*!< (@ 0x00000300) Programmable Gain Amp Monitor Output Control Register       */
 
         struct
         {

--- a/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T3BB.h
+++ b/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6T3BB.h
@@ -4500,9 +4500,9 @@ typedef struct                         /*!< (@ 0x4001B000) R_DEBUG Structure    
             __IOM uint32_t DBGSTOP_IWDT  : 1; /*!< [0..0] Mask bit for IWDT reset/interrupt                                  */
             __IOM uint32_t DBGSTOP_WDT   : 1; /*!< [1..1] Mask bit for WDT reset/interrupt                                   */
             uint32_t                     : 14;
-            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interupt                                  */
-            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interupt                                  */
+            __IOM uint32_t DBGSTOP_LVD0  : 1; /*!< [16..16] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD1  : 1; /*!< [17..17] Mask bit for LVD reset/interrupt                                  */
+            __IOM uint32_t DBGSTOP_LVD2  : 1; /*!< [18..18] Mask bit for LVD reset/interrupt                                  */
             uint32_t                     : 5;
             __IOM uint32_t DBGSTOP_RPER  : 1; /*!< [24..24] Mask bit for SRAM parity error                                   */
             __IOM uint32_t DBGSTOP_RECCR : 1; /*!< [25..25] Mask bit for SRAM ECC error                                      */

--- a/ra/fsp/src/bsp/mcu/all/bsp_clocks.c
+++ b/ra/fsp/src/bsp/mcu/all/bsp_clocks.c
@@ -1367,7 +1367,7 @@ void bsp_clock_init (void)
 
 #if BSP_CFG_STARTUP_CLOCK_REG_NOT_RESET
 
-    /* Transition to an intermediate clock configuration in order to prepare for writing the new clock configuraiton. */
+    /* Transition to an intermediate clock configuration in order to prepare for writing the new clock configuration. */
     bsp_soft_reset_prepare();
 #endif
 

--- a/ra/fsp/src/bsp/mcu/ra4e2/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra4e2/bsp_elc.h
@@ -91,13 +91,13 @@ typedef enum e_elc_event_ra4e2
     ELC_EVENT_RTC_ALARM              = (0x054), // Alarm interrupt
     ELC_EVENT_RTC_PERIOD             = (0x055), // Periodic interrupt
     ELC_EVENT_RTC_CARRY              = (0x056), // Carry interrupt
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN0_RXMB              = (0x067), // Receive message buffer interrupt
     ELC_EVENT_USBFS_INT              = (0x06D), // USBFS interrupt

--- a/ra/fsp/src/bsp/mcu/ra4t1/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra4t1/bsp_elc.h
@@ -88,13 +88,13 @@ typedef enum e_elc_event_ra4t1
     ELC_EVENT_AGT1_COMPARE_B         = (0x045), // Compare match B
     ELC_EVENT_IWDT_UNDERFLOW         = (0x052), // IWDT underflow
     ELC_EVENT_WDT_UNDERFLOW          = (0x053), // WDT underflow
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN0_RXMB              = (0x067), // Receive message buffer interrupt
     ELC_EVENT_ACMPHS0_INT            = (0x08E), // Comparator interrupt 0

--- a/ra/fsp/src/bsp/mcu/ra6e2/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra6e2/bsp_elc.h
@@ -91,13 +91,13 @@ typedef enum e_elc_event_ra6e2
     ELC_EVENT_RTC_ALARM              = (0x054), // Alarm interrupt
     ELC_EVENT_RTC_PERIOD             = (0x055), // Periodic interrupt
     ELC_EVENT_RTC_CARRY              = (0x056), // Carry interrupt
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN0_RXMB              = (0x067), // Receive message buffer interrupt
     ELC_EVENT_USBFS_INT              = (0x06D), // USBFS interrupt

--- a/ra/fsp/src/bsp/mcu/ra6m5/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra6m5/bsp_elc.h
@@ -105,7 +105,7 @@ typedef enum e_elc_event_ra6m5
     ELC_EVENT_RTC_ALARM              = (0x054), // Alarm interrupt
     ELC_EVENT_RTC_PERIOD             = (0x055), // Periodic interrupt
     ELC_EVENT_RTC_CARRY              = (0x056), // Carry interrupt
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
@@ -117,11 +117,11 @@ typedef enum e_elc_event_ra6m5
     ELC_EVENT_CAN_DMAREQ7            = (0x062), // DMA 7 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN1_TX                = (0x067), // Transmit interrupt
     ELC_EVENT_CAN1_CHERR             = (0x068), // Channel error
-    ELC_EVENT_CAN1_COMFRX            = (0x069), // Common FIFO recieve
+    ELC_EVENT_CAN1_COMFRX            = (0x069), // Common FIFO receive
     ELC_EVENT_CAN1_CF_DMAREQ         = (0x06A), // Channel DMA request
     ELC_EVENT_USBFS_FIFO_0           = (0x06B), // DMA transfer request 0
     ELC_EVENT_USBFS_FIFO_1           = (0x06C), // DMA transfer request 1

--- a/ra/fsp/src/bsp/mcu/ra6t2/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra6t2/bsp_elc.h
@@ -99,13 +99,13 @@ typedef enum e_elc_event_ra6t2
     ELC_EVENT_AGT1_COMPARE_B         = (0x045), // Compare match B
     ELC_EVENT_IWDT_UNDERFLOW         = (0x052), // IWDT underflow
     ELC_EVENT_WDT_UNDERFLOW          = (0x053), // WDT underflow
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN0_RXMB              = (0x067), // Receive message buffer interrupt
     ELC_EVENT_ACMPHS0_INT            = (0x08F), // Comparator interrupt 0

--- a/ra/fsp/src/bsp/mcu/ra6t2/bsp_override.h
+++ b/ra/fsp/src/bsp/mcu/ra6t2/bsp_override.h
@@ -112,8 +112,8 @@ typedef enum e_adc_channel
     ADC_CHANNEL_27 = 27,                 ///< ADC channel 27
     ADC_CHANNEL_28 = 28,                 ///< ADC channel 28
 
-    /* Extended Channels, See implimentation for details */
-    /* Implimentation specific extended channels */
+    /* Extended Channels, See implementation for details */
+    /* Implementation specific extended channels */
     ADC_CHANNEL_SELF_DIAGNOSIS = (0x60), ///< Self-Diagnosis channel
     ADC_CHANNEL_TEMPERATURE    = (0x61), ///< Temperature sensor output
     ADC_CHANNEL_VOLT           = (0x62), ///< Internal reference voltage

--- a/ra/fsp/src/bsp/mcu/ra6t3/bsp_elc.h
+++ b/ra/fsp/src/bsp/mcu/ra6t3/bsp_elc.h
@@ -88,13 +88,13 @@ typedef enum e_elc_event_ra6t3
     ELC_EVENT_AGT1_COMPARE_B         = (0x045), // Compare match B
     ELC_EVENT_IWDT_UNDERFLOW         = (0x052), // IWDT underflow
     ELC_EVENT_WDT_UNDERFLOW          = (0x053), // WDT underflow
-    ELC_EVENT_CAN_RXF                = (0x059), // Global recieve FIFO interrupt
+    ELC_EVENT_CAN_RXF                = (0x059), // Global receive FIFO interrupt
     ELC_EVENT_CAN_GLERR              = (0x05A), // Global error
     ELC_EVENT_CAN_DMAREQ0            = (0x05B), // DMA 0 request
     ELC_EVENT_CAN_DMAREQ1            = (0x05C), // DMA 1 request
     ELC_EVENT_CAN0_TX                = (0x063), // Transmit interrupt
     ELC_EVENT_CAN0_CHERR             = (0x064), // Channel error
-    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO recieve interrupt
+    ELC_EVENT_CAN0_COMFRX            = (0x065), // Common FIFO receive interrupt
     ELC_EVENT_CAN0_CF_DMAREQ         = (0x066), // Channel DMA request
     ELC_EVENT_CAN0_RXMB              = (0x067), // Receive message buffer interrupt
     ELC_EVENT_USBFS_INT              = (0x06D), // USBFS interrupt

--- a/ra/fsp/src/r_adc_b/r_adc_b.c
+++ b/ra/fsp/src/r_adc_b/r_adc_b.c
@@ -563,7 +563,7 @@ fsp_err_t R_ADC_B_CallbackSet (adc_ctrl_t * const          p_api_ctrl,
  * Enables the hardware trigger for a scan depending on how the triggers were configured in the R_ADC_B_ScanCfg call.
  * If the unit was configured for ELC, GPT, or external hardware triggering, then this function allows the trigger
  * signal to get to the ADC unit. The function is not able to control the generation of the trigger itself.
- * If the unit was configured for software triggering, This function was added to this ADC version for compatability
+ * If the unit was configured for software triggering, This function was added to this ADC version for compatibility
  * with r_adc driver. For additional flexibility, it is recommended to use R_ADC_B_ScanGroupStart.
  *
  * @pre Call R_ADC_B_ScanCfg after R_ADC_B_Open before starting a scan.
@@ -989,19 +989,19 @@ static void adc_b_calculate_wait_time (adc_b_instance_ctrl_t * p_instance_ctrl, 
         bool     sync_enabled                 = sync_enabled_lut[p_adc_group->converter_selection];
         uint32_t trigger_delay                = p_extend->start_trigger_delay_table[group];
 
-        uint32_t caclulated_cycles = 0;
+        uint32_t calculated_cycles = 0;
         if (sync_enabled)
         {
-            caclulated_cycles = trigger_delay + sync_cycles * 2;
+            calculated_cycles = trigger_delay + sync_cycles * 2;
         }
         else
         {
-            caclulated_cycles = trigger_delay + 4;
+            calculated_cycles = trigger_delay + 4;
         }
 
-        if (wait_cycles < caclulated_cycles)
+        if (wait_cycles < calculated_cycles)
         {
-            wait_cycles = caclulated_cycles;
+            wait_cycles = calculated_cycles;
         }
     }
 
@@ -1788,7 +1788,7 @@ void adc_b_fiforeq5678_isr (void)
     /* Save context if RTOS is used */
     FSP_CONTEXT_SAVE
 
-    /* Get groups with less data availabe than threshold */
+    /* Get groups with less data available than threshold */
     adc_group_mask_t group = (adc_group_mask_t) (ADC_B_GROUP_MASK_5678 & R_ADC_B->ADFIFOERSR_b.FIFOFLFn);
     IRQn_Type        irq   = adc_b_isr_handler(ADC_EVENT_FIFO_READ_REQUEST,
                                                group,

--- a/ra/fsp/src/r_agt/r_agt.c
+++ b/ra/fsp/src/r_agt/r_agt.c
@@ -1156,7 +1156,7 @@ void agt_int_isr (void)
             *p_instance_ctrl->p_callback_memory = callback_args;
         }
 
-        /* Retreive AGTCR in case it was modified in the callback. */
+        /* Retrieve AGTCR in case it was modified in the callback. */
         agtcr = p_reg_ctrl->AGTCR;
     }
 

--- a/ra/fsp/src/r_canfd/r_canfd.c
+++ b/ra/fsp/src/r_canfd/r_canfd.c
@@ -1166,7 +1166,7 @@ void canfd_error_isr (void)
     {
 #if BSP_FEATURE_CANFD_NUM_INSTANCES > 1
 
-        /* If there are seperate instances of CANFD, then loop over each instance to handle the source of the global
+        /* If there are separate instances of CANFD, then loop over each instance to handle the source of the global
          * error IRQ. */
         for (uint32_t i = 0; i < BSP_FEATURE_CANFD_NUM_INSTANCES; i++)
         {
@@ -1280,7 +1280,7 @@ void canfd_rx_fifo_isr (void)
 
 #if BSP_FEATURE_CANFD_NUM_INSTANCES > 1
 
-    /* If there are seperate instances of CANFD, then loop over each instance to handle the source of the global
+    /* If there are separate instances of CANFD, then loop over each instance to handle the source of the global
      * receive IRQ. */
     for (uint32_t i = 0; i < BSP_FEATURE_CANFD_NUM_INSTANCES; i++)
     {

--- a/ra/fsp/src/r_cgc/r_cgc.c
+++ b/ra/fsp/src/r_cgc/r_cgc.c
@@ -1957,7 +1957,7 @@ static fsp_err_t r_cgc_pll_hz_calculate (cgc_pll_cfg_t const * const p_pll_cfg,
     /* Convert the MULNF value to use a common multiple of 6. */
     if (fractional < 3U)
     {
-        /* Values for 1/3 and 2/3 are 1 and 2 respectivly therefore it only needs a coefficient of 2 applied. */
+        /* Values for 1/3 and 2/3 are 1 and 2 respectively therefore it only needs a coefficient of 2 applied. */
         fractional *= CGC_PRV_PLL_MUL_NF_COEFF;
     }
     else

--- a/ra/fsp/src/r_crc/r_crc.c
+++ b/ra/fsp/src/r_crc/r_crc.c
@@ -228,7 +228,7 @@ fsp_err_t R_CRC_CalculatedValueGet (crc_ctrl_t * const p_ctrl, uint32_t * calcul
  * sent to the CRC calculator as if the value was explicitly written directly to the CRC calculator.
  *
  * @retval FSP_SUCCESS                  Snoop configured successfully.
- * @retval FSP_ERR_ASSERTION            Pointer to control stucture is NULL
+ * @retval FSP_ERR_ASSERTION            Pointer to control structure is NULL
  * @retval FSP_ERR_NOT_OPEN             The driver is not opened.
  * @retval FSP_ERR_UNSUPPORTED          SNOOP operation is not supported.
  * @retval FSP_ERR_INVALID_ARGUMENT     SNOOP address is invalid.

--- a/ra/fsp/src/r_dmac/r_dmac.c
+++ b/ra/fsp/src/r_dmac/r_dmac.c
@@ -112,7 +112,7 @@ static void      r_dmac_config_transfer_info(dmac_instance_ctrl_t * p_ctrl, tran
 
 #if DMAC_CFG_PARAM_CHECKING_ENABLE
 static fsp_err_t r_dma_open_parameter_checking(dmac_instance_ctrl_t * const p_ctrl, transfer_cfg_t const * const p_cfg);
-static fsp_err_t r_dmac_reconfigure_paramter_checking(transfer_info_t const * const p_info);
+static fsp_err_t r_dmac_reconfigure_parameter_checking(transfer_info_t const * const p_info);
 static fsp_err_t r_dmac_enable_parameter_checking(dmac_instance_ctrl_t * const p_ctrl);
 
 #endif
@@ -201,7 +201,7 @@ fsp_err_t R_DMAC_Reconfigure (transfer_ctrl_t * const p_api_ctrl, transfer_info_
 #if DMAC_CFG_PARAM_CHECKING_ENABLE
     FSP_ASSERT(p_ctrl != NULL);
     FSP_ERROR_RETURN(p_ctrl->open == DMAC_ID, FSP_ERR_NOT_OPEN);
-    err = r_dmac_reconfigure_paramter_checking(p_info);
+    err = r_dmac_reconfigure_parameter_checking(p_info);
     FSP_ERROR_RETURN(FSP_SUCCESS == err, err);
 #endif
 
@@ -650,7 +650,7 @@ static fsp_err_t r_dma_open_parameter_checking (dmac_instance_ctrl_t * const p_c
         FSP_ERROR_RETURN(p_extend->irq >= 0, FSP_ERR_IRQ_BSP_DISABLED);
     }
 
-    fsp_err_t err = r_dmac_reconfigure_paramter_checking(p_cfg->p_info);
+    fsp_err_t err = r_dmac_reconfigure_parameter_checking(p_cfg->p_info);
     FSP_ERROR_RETURN(FSP_SUCCESS == err, err);
 
     return FSP_SUCCESS;
@@ -664,7 +664,7 @@ static fsp_err_t r_dma_open_parameter_checking (dmac_instance_ctrl_t * const p_c
  * @retval FSP_SUCCESS              The transfer info is valid.
  * @retval FSP_ERR_ASSERTION        A transfer info setting is invalid.
  **********************************************************************************************************************/
-static fsp_err_t r_dmac_reconfigure_paramter_checking (transfer_info_t const * const p_info)
+static fsp_err_t r_dmac_reconfigure_parameter_checking (transfer_info_t const * const p_info)
 {
     FSP_ASSERT(p_info != NULL);
 

--- a/ra/fsp/src/r_ether/r_ether.c
+++ b/ra/fsp/src/r_ether/r_ether.c
@@ -1801,7 +1801,7 @@ static uint8_t ether_check_magic_packet_detection_bit (ether_instance_ctrl_t con
 }                                      /* End of function ether_check_magic_packet_detection_bit() */
 
 /*******************************************************************************************************************//**
- * @brief Verifies the Etherent link is up or not.
+ * @brief Verifies the Ethernet link is up or not.
  *
  * @param[in] p_instance_ctrl   Pointer to the control block for the channel
  *

--- a/ra/fsp/src/r_flash_hp/r_flash_hp.c
+++ b/ra/fsp/src/r_flash_hp/r_flash_hp.c
@@ -1217,7 +1217,7 @@ fsp_err_t R_FLASH_HP_CallbackSet (flash_ctrl_t * const          p_api_ctrl,
  * @param[in]  write_size          The write size
  * @param[in]  timeout             The timeout
  *
- * @retval     FSP_SUCCESS         Write completed succesfully
+ * @retval     FSP_SUCCESS         Write completed successfully
  * @retval     FSP_ERR_TIMEOUT     Flash timed out during write operation.
  **********************************************************************************************************************/
 static fsp_err_t flash_hp_write_data (flash_hp_instance_ctrl_t * const p_ctrl, uint32_t write_size, uint32_t timeout)
@@ -1297,7 +1297,7 @@ static fsp_err_t flash_hp_write_data (flash_hp_instance_ctrl_t * const p_ctrl, u
  * @param[in]  error_bits          The error bits
  * @param[in]  return_error        The return error
  *
- * @retval     FSP_SUCCESS         Command completed succesfully
+ * @retval     FSP_SUCCESS         Command completed successfully
  * @retval     FSP_ERR_CMD_LOCKED  Flash entered command locked state
  **********************************************************************************************************************/
 static fsp_err_t flash_hp_check_errors (fsp_err_t previous_error, uint32_t error_bits, fsp_err_t return_error)
@@ -1728,7 +1728,7 @@ static fsp_err_t flash_hp_df_blank_check (flash_hp_instance_ctrl_t * const p_ctr
 /*******************************************************************************************************************//**
  * This function will initialize the FCU and set the FCU Clock based on the current FCLK frequency.
  * @param      p_ctrl        Pointer to the instance control block
- * @retval     FSP_SUCCESS   Clock and timeouts configured succesfully.
+ * @retval     FSP_SUCCESS   Clock and timeouts configured successfully.
  * @retval     FSP_ERR_FCLK  FCLK is not within the acceptable range.
  **********************************************************************************************************************/
 static fsp_err_t flash_hp_init (flash_hp_instance_ctrl_t * p_ctrl)

--- a/ra/fsp/src/r_flash_lp/r_flash_lp.c
+++ b/ra/fsp/src/r_flash_lp/r_flash_lp.c
@@ -1117,7 +1117,7 @@ static fsp_err_t r_flash_lp_setup (flash_lp_instance_ctrl_t * p_ctrl)
  * @param      p_ctrl                   Pointer to the control block
  * @param[in]  flash_address            The flash address
  * @param[in]  num_bytes                The number bytes
- * @param[in]  check_write              Check paramters for writing.
+ * @param[in]  check_write              Check parameters for writing.
  *
  * @retval     FSP_SUCCESS              Parameter checking completed without error.
  * @retval     FSP_ERR_NOT_OPEN         The Flash API is not Open.
@@ -2589,7 +2589,7 @@ static fsp_err_t r_flash_lp_wait_for_ready (flash_lp_instance_ctrl_t * const p_c
 /*******************************************************************************************************************//**
  * Set the flash interface peripheral clock frequency
  * @param      p_ctrl           Pointer to the interface control block
- * @retval     FSP_SUCCESS      Flash interface clock frequency succesfully configured.
+ * @retval     FSP_SUCCESS      Flash interface clock frequency successfully configured.
  * @retval     FSP_ERR_TIMEOUT  Setting the flash interface clock frequency timed out.
  **********************************************************************************************************************/
 fsp_err_t r_flash_lp_set_fisr (flash_lp_instance_ctrl_t * const p_ctrl)

--- a/ra/fsp/src/r_i3c/r_i3c.c
+++ b/ra/fsp/src/r_i3c/r_i3c.c
@@ -1766,7 +1766,7 @@ void i3c_resp_isr (void)
                 }
                 else
                 {
-                    /* If the command was not successfull, re-enable the IBI Write Buffer Empty/Full IRQ. */
+                    /* If the command was not successful, re-enable the IBI Write Buffer Empty/Full IRQ. */
                     p_ctrl->p_reg->NTIE_b.IBIQEFIE = 1;
                 }
             }
@@ -1954,7 +1954,7 @@ void i3c_rcv_isr (void)
             callback_args.transfer_size = data_length;
             callback_args.event         = I3C_EVENT_READ_COMPLETE;
 
-            /* Reset ther state for read transfers. */
+            /* Reset there state for read transfers. */
             p_ctrl->read_buffer_descriptor = (i3c_read_buffer_descriptor_t) {
                 0
             };
@@ -2045,7 +2045,7 @@ void i3c_rcv_isr (void)
                     /*
                      * In slave mode the IBI Queue Empty/Full flag indicates that the queue is empty. After transitioning to
                      * master mode, this bit indicates if there is status information in the queue. If the IBI queue was empty
-                     * before tranistioning to master mode, then it will be set and the status should be cleared.
+                     * before transitioning to master mode, then it will be set and the status should be cleared.
                      */
                     p_ctrl->p_reg->NTST_b.IBIQEFF = 0;
                 }

--- a/ra/fsp/src/r_icu/r_icu.c
+++ b/ra/fsp/src/r_icu/r_icu.c
@@ -336,7 +336,7 @@ void r_icu_isr (void)
             /* Save current state of p_callback_args so that it can be shared between interrupts. */
             args = *p_ctrl->p_callback_memory;
 
-            /* Set the callback args passed to the Non-secure calback. */
+            /* Set the callback args passed to the Non-secure callback. */
             p_ctrl->p_callback_memory->channel   = p_ctrl->channel;
             p_ctrl->p_callback_memory->p_context = p_ctrl->p_context;
 

--- a/ra/fsp/src/r_ioport/r_ioport.c
+++ b/ra/fsp/src/r_ioport/r_ioport.c
@@ -402,7 +402,7 @@ fsp_err_t R_IOPORT_PinWrite (ioport_ctrl_t * const p_ctrl, bsp_io_port_pin_t pin
         setbits = pin_mask;
     }
 
-    /* PCNTR register is updated instead of using PFS as access is atomic and PFS requires seperate enable/disable
+    /* PCNTR register is updated instead of using PFS as access is atomic and PFS requires separate enable/disable
      * using PWPR register */
 
     /* Get the port address */

--- a/ra/fsp/src/r_lpm/r_lpm.c
+++ b/ra/fsp/src/r_lpm/r_lpm.c
@@ -185,7 +185,7 @@ fsp_err_t R_LPM_Open (lpm_ctrl_t * const p_api_ctrl, lpm_cfg_t const * const p_c
  * NOTE: This function does not enter the low power mode, it only configures parameters of the mode. Execution of the
  * WFI instruction is what causes the low power mode to be entered.
  *
- * @retval     FSP_SUCCESS                   Low power mode successfuly applied
+ * @retval     FSP_SUCCESS                   Low power mode successfully applied
  * @retval     FSP_ERR_ASSERTION             Null Pointer
  * @retval     FSP_ERR_NOT_OPEN              LPM instance is not open
  * @retval     FSP_ERR_UNSUPPORTED           This MCU does not support Deep Software Standby

--- a/ra/fsp/src/r_lvd/r_lvd.c
+++ b/ra/fsp/src/r_lvd/r_lvd.c
@@ -802,7 +802,7 @@ static fsp_err_t lvd_open_parameter_check (lvd_instance_ctrl_t * p_ctrl, lvd_cfg
 #endif
 
 /***********************************************************************************************************************
- * Private funtions configurate LVD of VBAT, RTC, EX
+ * Private funtions configure LVD of VBAT, RTC, EX
  *
  * @param[in] p_ctrl            Pointer to the control block structure for the driver instance
  *

--- a/ra/fsp/src/r_ospi/r_ospi.c
+++ b/ra/fsp/src/r_ospi/r_ospi.c
@@ -406,7 +406,7 @@ fsp_err_t R_OSPI_Write (spi_flash_ctrl_t * const p_ctrl,
         err = p_transfer->p_api->softwareStart(p_transfer->p_ctrl, TRANSFER_START_MODE_SINGLE);
         FSP_ERROR_RETURN(FSP_SUCCESS == err, err);
 
-        /* Wait for DMAC to complete to maintain deterministic processing and backward compatability */
+        /* Wait for DMAC to complete to maintain deterministic processing and backward compatibility */
         transfer_properties_t transfer_properties = {0U};
         err = p_transfer->p_api->infoGet(p_transfer->p_ctrl, &transfer_properties);
         FSP_ERROR_RETURN(FSP_SUCCESS == err, err);

--- a/ra/fsp/src/r_ptp/r_edmac/r_edmac.c
+++ b/ra/fsp/src/r_ptp/r_edmac/r_edmac.c
@@ -121,7 +121,7 @@ fsp_err_t R_EDMAC_Open (edmac_instance_ctrl_t * const p_ctrl, edmac_cfg_t const 
     p_ctrl->p_reg->RDLAR = (uint32_t) p_cfg->p_rx_descriptors;
 
     /*
-     * Set the fifo depth register acording to the hardware manual
+     * Set the fifo depth register according to the hardware manual
      * (Reference section 31.2.13 FIFO Depth Register (FDR) in the RA6M3 manual R01UH0886EJ0100).
      */
     p_ctrl->p_reg->FDR = EDMAC_FDR_VALUE;

--- a/ra/fsp/src/r_ptp/r_ptp.c
+++ b/ra/fsp/src/r_ptp/r_ptp.c
@@ -256,7 +256,7 @@ void r_ptp_ipls_isr(void);
  * Private global variables
  **********************************************************************************************************************/
 
-/* Lookup table for calcualting TSLATR. */
+/* Lookup table for calculating TSLATR. */
 static const ptp_tslatr_setting_t g_tslatr_lut[2][2][4] =
 {
     /* MMI */
@@ -395,7 +395,7 @@ const ptp_api_t g_ptp_api =
  *
  * This function performs the following tasks:
  * - Performs parameter checking and processes error conditions.
- * - Configures the peripheral registers acording to the configuration.
+ * - Configures the peripheral registers according to the configuration.
  * - Initialize the control structure for use in other @ref PTP_API functions.
  *
  * @retval     FSP_SUCCESS                     The instance has been successfully configured.
@@ -1280,13 +1280,13 @@ static void r_ptp_hw_config (ptp_instance_ctrl_t * p_instance_ctrl)
     /* Set the number of times the offsetFromMaster must be above the threshold for sync to be lost. */
     uint32_t stmr = (uint32_t) (p_cfg->stca.sync_threshold.count << R_ETHERC_EPTPC_COMMON_STMR_DVTH_Pos);
 
-    /* Set the number of times the offsetFromMaster must be below the threshold for sync to be aquired. */
+    /* Set the number of times the offsetFromMaster must be below the threshold for sync to be acquired. */
     stmr |= (uint32_t) (p_cfg->stca.sync_loss_threshold.count << R_ETHERC_EPTPC_COMMON_STMR_SYTH_Pos);
 
     /* Enable the SYNCOUT and SYNTOUT flags in STSR. */
     stmr |= R_ETHERC_EPTPC_COMMON_STMR_ALEN0_Msk | R_ETHERC_EPTPC_COMMON_STMR_ALEN1_Msk;
 
-    /* Configure gradient worst10 aquisition. */
+    /* Configure gradient worst10 acquisition. */
     if (PTP_CLOCK_CORRECTION_MODE2 == p_cfg->stca.clock_correction_mode)
     {
         /* Enable clock correction mode 2. */
@@ -2167,7 +2167,7 @@ void r_ptp_mint_isr (void)
              * (See 30.2.5 of the RA6M3 manual R01UH0886EJ0100). */
             stsr |= R_ETHERC_EPTPC_COMMON_STSR_SYNTOUT_Msk | R_ETHERC_EPTPC_COMMON_STSR_SYNCOUT_Msk;
 
-            /* Start syncronization. */
+            /* Start synchronization. */
             R_ETHERC_EPTPC_COMMON->SYNSTARTR = 1U;
 
             if (PTP_CLOCK_CORRECTION_MODE2 == p_instance_ctrl->p_cfg->stca.clock_correction_mode)

--- a/ra/fsp/src/r_rtc/r_rtc.c
+++ b/ra/fsp/src/r_rtc/r_rtc.c
@@ -148,7 +148,7 @@ static void r_rtc_call_callback(rtc_instance_ctrl_t * p_ctrl, rtc_event_t event)
 #if RTC_CFG_PARAM_CHECKING_ENABLE
 static fsp_err_t r_rtc_rfrl_validate(uint32_t value);
 
-static fsp_err_t r_rtc_err_adjustment_paramter_check(rtc_error_adjustment_cfg_t const * const err_adj_cfg);
+static fsp_err_t r_rtc_err_adjustment_parameter_check(rtc_error_adjustment_cfg_t const * const err_adj_cfg);
 
 static fsp_err_t r_rtc_time_and_date_validate(rtc_time_t * const p_time);
 
@@ -223,7 +223,7 @@ fsp_err_t R_RTC_Open (rtc_ctrl_t * const p_ctrl, rtc_cfg_t const * const p_cfg)
     /* Validate the error adjustment parameters when using SubClock */
     else
     {
-        FSP_ERROR_RETURN(FSP_SUCCESS == r_rtc_err_adjustment_paramter_check(p_instance_ctrl->p_cfg->p_err_cfg),
+        FSP_ERROR_RETURN(FSP_SUCCESS == r_rtc_err_adjustment_parameter_check(p_instance_ctrl->p_cfg->p_err_cfg),
                          FSP_ERR_INVALID_ARGUMENT);
     }
 #endif
@@ -775,7 +775,7 @@ fsp_err_t R_RTC_ErrorAdjustmentSet (rtc_ctrl_t * const p_ctrl, rtc_error_adjustm
     }
 
     /* Verify the frequecy comparison valure for RFRL when using LOCO */
-    FSP_ERROR_RETURN(FSP_SUCCESS == r_rtc_err_adjustment_paramter_check(err_adj_cfg), FSP_ERR_INVALID_ARGUMENT);
+    FSP_ERROR_RETURN(FSP_SUCCESS == r_rtc_err_adjustment_parameter_check(err_adj_cfg), FSP_ERR_INVALID_ARGUMENT);
 #else
     FSP_PARAMETER_NOT_USED(p_instance_ctrl);
 #endif
@@ -1055,7 +1055,7 @@ static void r_rtc_call_callback (rtc_instance_ctrl_t * p_ctrl, rtc_event_t event
 /*******************************************************************************************************************//**
  * Validate RFRL value for LOCO
  *
- * @param[in]  value                      Frequency Comparision Value
+ * @param[in]  value                      Frequency Comparison Value
  * @retval FSP_SUCCESS                    validation successful
  * @retval FSP_ERR_INVALID_ARGUMENT       invalid field in rtc_time_t structure
  **********************************************************************************************************************/
@@ -1082,7 +1082,7 @@ static fsp_err_t r_rtc_rfrl_validate (uint32_t value)
  * @retval FSP_SUCCESS                 Validation successful
  * @retval FSP_ERR_INVALID_ARGUMENT    Invalid error configuration
  **********************************************************************************************************************/
-static fsp_err_t r_rtc_err_adjustment_paramter_check (rtc_error_adjustment_cfg_t const * const err_adj_cfg)
+static fsp_err_t r_rtc_err_adjustment_parameter_check (rtc_error_adjustment_cfg_t const * const err_adj_cfg)
 {
     rtc_error_adjustment_mode_t   mode   = err_adj_cfg->adjustment_mode;
     rtc_error_adjustment_period_t period = err_adj_cfg->adjustment_period;

--- a/ra/fsp/src/r_sci_b_spi/r_sci_b_spi.c
+++ b/ra/fsp/src/r_sci_b_spi/r_sci_b_spi.c
@@ -744,7 +744,7 @@ static fsp_err_t r_sci_b_spi_write_read_common (sci_b_spi_instance_ctrl_t * cons
 static void r_sci_b_spi_start_transfer (sci_b_spi_instance_ctrl_t * const p_ctrl)
 {
     /* TE must always be enabled even when receiving data. When RE is enabled without also enabling TE, the SCI will
-     * continue transfering data until the RE bit is cleared. At high bitrates, it is not possible to clear the RE bit
+     * continue transferring data until the RE bit is cleared. At high bitrates, it is not possible to clear the RE bit
      * fast enough and there will be additional clock pulses at the end of the transfer. */
     uint32_t interrupt_settings = R_SCI_B0_CCR0_TE_Msk;
 
@@ -868,7 +868,7 @@ static void r_sci_b_spi_call_callback (sci_b_spi_instance_ctrl_t * p_ctrl, spi_e
  * The Transmit Buffer Empty IRQ is enabled in the following conditions:
  *   - The transfer is started using R_SCI_B_SPI_Write API (There is no data to receive).
  *   - The rxi IRQ is serviced using a DTC instance.
- *   - The txi IRQ is serviced using a DTC instance (The interrupt will fire on the last byte transfered).
+ *   - The txi IRQ is serviced using a DTC instance (The interrupt will fire on the last byte transferred).
  *
  **********************************************************************************************************************/
 void sci_b_spi_txi_isr (void)
@@ -942,7 +942,7 @@ void sci_b_spi_rxi_isr (void)
 /*******************************************************************************************************************//**
  * This function is the ISR handler for R_SCI_SPI Transmit End IRQ.
  *
- * The Transmit End IRQ is enabled after the last byte of data has been transfered.
+ * The Transmit End IRQ is enabled after the last byte of data has been transferred.
  *
  **********************************************************************************************************************/
 void sci_b_spi_tei_isr (void)

--- a/ra/fsp/src/r_sci_b_uart/r_sci_b_uart.c
+++ b/ra/fsp/src/r_sci_b_uart/r_sci_b_uart.c
@@ -978,8 +978,8 @@ fsp_err_t R_SCI_B_UART_BaudCalculate (uint32_t                     baudrate,
     {
         for (uint32_t i = 0U; i < SCI_B_UART_NUM_DIVISORS_ASYNC; i++)
         {
-            /* if select_16_base_clk_cycles == true:  Skip this calculation for divisors that are not acheivable with 16 base clk cycles per bit.
-             *  if select_16_base_clk_cycles == false: Skip this calculation for divisors that are only acheivable without 16 base clk cycles per bit.
+            /* if select_16_base_clk_cycles == true:  Skip this calculation for divisors that are not achievable with 16 base clk cycles per bit.
+             *  if select_16_base_clk_cycles == false: Skip this calculation for divisors that are only achievable without 16 base clk cycles per bit.
              */
             if (((uint8_t) select_16_base_clk_cycles) ^ (g_async_baud[i].abcs | g_async_baud[i].abcse))
             {

--- a/ra/fsp/src/r_sci_smci/r_sci_smci.c
+++ b/ra/fsp/src/r_sci_smci/r_sci_smci.c
@@ -204,7 +204,7 @@ const smci_api_t g_smci_on_sci =
  * expected should the transfer mode be changed after reset.  Implements @ref smci_api_t::open
  *
  * @param[inout]  p_api_ctrl               Pointer to SMCI control block that is to be opened
- * @param[in] p_cfg                        Pointer to the config structure that shall be used to set paramters of the SMCI
+ * @param[in] p_cfg                        Pointer to the config structure that shall be used to set parameters of the SMCI
  *                                         baud calculations needed to be have done and set into
  *                                         p_cfg->p_extend->p_smci_baud_setting
  *

--- a/ra/fsp/src/r_sci_spi/r_sci_spi.c
+++ b/ra/fsp/src/r_sci_spi/r_sci_spi.c
@@ -771,7 +771,7 @@ static fsp_err_t r_sci_spi_write_read_common (sci_spi_instance_ctrl_t * const p_
 static void r_sci_spi_start_transfer (sci_spi_instance_ctrl_t * const p_ctrl)
 {
     /* TE must always be enabled even when receiving data. When RE is enabled without also enabling TE, the SCI will
-     * continue transfering data until the RE bit is cleared. At high bitrates, it is not possible to clear the RE bit
+     * continue transferring data until the RE bit is cleared. At high bitrates, it is not possible to clear the RE bit
      * fast enough and there will be additional clock pulses at the end of the transfer. */
     uint32_t interrupt_settings = R_SCI0_SCR_TE_Msk;
 
@@ -895,7 +895,7 @@ static void r_sci_spi_call_callback (sci_spi_instance_ctrl_t * p_ctrl, spi_event
  * The Transmit Buffer Empty IRQ is enabled in the following conditions:
  *   - The transfer is started using R_SCI_SPI_Write API (There is no data to receive).
  *   - The rxi IRQ is serviced using a DTC instance.
- *   - The txi IRQ is serviced using a DTC instance (The interrupt will fire on the last byte transfered).
+ *   - The txi IRQ is serviced using a DTC instance (The interrupt will fire on the last byte transferred).
  *
  **********************************************************************************************************************/
 void sci_spi_txi_isr (void)
@@ -961,7 +961,7 @@ void sci_spi_rxi_isr (void)
 /*******************************************************************************************************************//**
  * This function is the ISR handler for R_SCI_SPI Transmit End IRQ.
  *
- * The Transmit End IRQ is enabled after the last byte of data has been transfered.
+ * The Transmit End IRQ is enabled after the last byte of data has been transferred.
  *
  **********************************************************************************************************************/
 void sci_spi_tei_isr (void)

--- a/ra/fsp/src/r_sci_uart/r_sci_uart.c
+++ b/ra/fsp/src/r_sci_uart/r_sci_uart.c
@@ -1009,8 +1009,8 @@ fsp_err_t R_SCI_UART_BaudCalculate (uint32_t               baudrate,
     {
         for (uint32_t i = 0U; i < SCI_UART_NUM_DIVISORS_ASYNC; i++)
         {
-            /* if select_16_base_clk_cycles == true:  Skip this calculation for divisors that are not acheivable with 16 base clk cycles per bit.
-             *  if select_16_base_clk_cycles == false: Skip this calculation for divisors that are only acheivable without 16 base clk cycles per bit.
+            /* if select_16_base_clk_cycles == true:  Skip this calculation for divisors that are not achievable with 16 base clk cycles per bit.
+             *  if select_16_base_clk_cycles == false: Skip this calculation for divisors that are only achievable without 16 base clk cycles per bit.
              */
             if (((uint8_t) select_16_base_clk_cycles) ^ (g_async_baud[i].abcs | g_async_baud[i].abcse))
             {

--- a/ra/fsp/src/r_sdhi/r_sdhi.c
+++ b/ra/fsp/src/r_sdhi/r_sdhi.c
@@ -1115,7 +1115,7 @@ fsp_err_t R_SDHI_Close (sdmmc_ctrl_t * const p_api_ctrl)
     p_ctrl->p_cfg->p_lower_lvl_transfer->p_api->close(p_ctrl->p_cfg->p_lower_lvl_transfer->p_ctrl);
 
     /* Do not set the module stop bit since the CMD0 may not be complete yet. Do not wait for CMD0 to complete because
-     * the card could be unplugged and waiting for the response timeout in this function is not desireable. */
+     * the card could be unplugged and waiting for the response timeout in this function is not desirable. */
 
     return FSP_SUCCESS;
 }

--- a/ra/fsp/src/r_sdhi/r_sdhi_private.h
+++ b/ra/fsp/src/r_sdhi/r_sdhi_private.h
@@ -87,7 +87,7 @@ FSP_HEADER
 #define SDHI_PRV_SDIO_CMD52_READ                        (0U)
 #define SDHI_PRV_SDIO_CMD52_WRITE                       (1U)
 
-/* SWITCH command argument's bit postion */
+/* SWITCH command argument's bit position */
 #define SDHI_PRV_SWITCH_ACCESS_SHIFT                    (24U)
 #define SDHI_PRV_SWITCH_INDEX_SHIFT                     (16U)
 #define SDHI_PRV_SWITCH_VALUE_SHIFT                     (8U)

--- a/ra/fsp/src/r_spi/r_spi.c
+++ b/ra/fsp/src/r_spi/r_spi.c
@@ -146,7 +146,7 @@ const spi_api_t g_spi_on_spi =
  *
  * This function performs the following tasks:
  * - Performs parameter checking and processes error conditions.
- * - Configures the pperipheral registers acording to the configuration.
+ * - Configures the pperipheral registers according to the configuration.
  * - Initialize the control structure for use in other @ref SPI_API functions.
  *
  * @retval     FSP_SUCCESS                     Channel initialized successfully.
@@ -708,7 +708,7 @@ static void r_spi_nvic_config (spi_instance_ctrl_t * p_ctrl)
 
     R_BSP_IrqCfg(p_ctrl->p_cfg->tei_irq, p_ctrl->p_cfg->tei_ipl, p_ctrl);
 
-    /* Note tei_irq is not enabled until the last data frame is transfered. */
+    /* Note tei_irq is not enabled until the last data frame is transferred. */
 }
 
 /*******************************************************************************************************************//**
@@ -1150,7 +1150,7 @@ void spi_tx_dmac_callback (spi_instance_ctrl_t const * const p_ctrl)
         /* Only enable the transfer end ISR if there are no receive buffer full interrupts expected to be handled
          * after this interrupt. */
 
-        /* If DMA is used to transmit data, enable the interrupt after all the data has been transfered, but do not
+        /* If DMA is used to transmit data, enable the interrupt after all the data has been transferred, but do not
          * clear the IRQ Pending Bit. */
         R_BSP_IrqEnableNoClear(p_ctrl->p_cfg->tei_irq);
     }
@@ -1188,7 +1188,7 @@ void spi_txi_isr (void)
         }
         else if (p_ctrl->p_cfg->p_transfer_tx)
         {
-            /* If DMA is used to transmit data, enable the interrupt after all the data has been transfered, but do not
+            /* If DMA is used to transmit data, enable the interrupt after all the data has been transferred, but do not
              * clear the IRQ Pending Bit. */
             R_BSP_IrqEnableNoClear(p_ctrl->p_cfg->tei_irq);
         }

--- a/ra/fsp/src/r_spi_b/r_spi_b.c
+++ b/ra/fsp/src/r_spi_b/r_spi_b.c
@@ -657,7 +657,7 @@ static void r_spi_b_nvic_config (spi_b_instance_ctrl_t * p_ctrl)
 
     R_BSP_IrqCfg(p_ctrl->p_cfg->tei_irq, p_ctrl->p_cfg->tei_ipl, p_ctrl);
 
-    /* Note tei_irq is not enabled until the last data frame is transfered. */
+    /* Note tei_irq is not enabled until the last data frame is transferred. */
 }
 
 /*******************************************************************************************************************//**
@@ -1049,7 +1049,7 @@ void spi_b_txi_isr (void)
         }
         else if (p_ctrl->p_cfg->p_transfer_tx)
         {
-            /* If DMA is used to transmit data, enable the interrupt after all the data has been transfered, but do not
+            /* If DMA is used to transmit data, enable the interrupt after all the data has been transferred, but do not
              * clear the IRQ Pending Bit. */
             R_BSP_IrqEnableNoClear(p_ctrl->p_cfg->tei_irq);
         }

--- a/ra/fsp/src/r_ulpt/r_ulpt.c
+++ b/ra/fsp/src/r_ulpt/r_ulpt.c
@@ -877,7 +877,7 @@ void ulpt_int_isr (void)
             *p_instance_ctrl->p_callback_memory = callback_args;
         }
 
-        /* Retreive AGTCR in case it was modified in the callback. */
+        /* Retrieve AGTCR in case it was modified in the callback. */
         ulptcr = p_instance_ctrl->p_reg->ULPTCR;
     }
 

--- a/ra/fsp/src/r_usb_basic/r_usb_basic.c
+++ b/ra/fsp/src/r_usb_basic/r_usb_basic.c
@@ -423,7 +423,7 @@ fsp_err_t R_USB_Open (usb_ctrl_t * const p_api_ctrl, usb_cfg_t const * const p_c
 
 #if ((USB_CFG_MODE & USB_CFG_HOST) == USB_CFG_HOST)
  #if USB_CFG_COMPLIANCE == USB_CFG_ENABLE
-    g_usb_compliance_callback[p_ctrl->module_number] = p_cfg->usb_complience_cb;
+    g_usb_compliance_callback[p_ctrl->module_number] = p_cfg->usb_compliance_cb;
  #endif                                /* #if USB_CFG_COMPLIANCE == USB_CFG_ENABLE */
 #endif                                 /* #if ((USB_CFG_MODE & USB_CFG_HOST) == USB_CFG_HOST) */
 
@@ -1385,7 +1385,7 @@ fsp_err_t R_USB_Close (usb_ctrl_t * const p_api_ctrl)
             usb_rtos_delete(p_ctrl->module_number);
 
             /* Remove settings that prevent preemption. */
-            tx_thread_preemption_change(now_thread, old_threshold, &old_threshold); /* Enable dispath ti the other task */
+            tx_thread_preemption_change(now_thread, old_threshold, &old_threshold); /* Enable dispatch ti the other task */
    #else                                                                            /* (BSP_CFG_RTOS == 1) */
             usb_rtos_delete(p_ctrl->module_number);
    #endif  /* (BSP_CFG_RTOS == 1) */
@@ -1401,7 +1401,7 @@ fsp_err_t R_USB_Close (usb_ctrl_t * const p_api_ctrl)
         usb_rtos_delete(p_ctrl->module_number);
 
         /* Remove settings that prevent preemption. */
-        tx_thread_preemption_change(now_thread, old_threshold, &old_threshold); /* Enable dispath ti the other task */
+        tx_thread_preemption_change(now_thread, old_threshold, &old_threshold); /* Enable dispatch ti the other task */
    #else                                                                        /* (BSP_CFG_RTOS == 1) */
         usb_rtos_delete(p_ctrl->module_number);
    #endif  /* (BSP_CFG_RTOS == 1) */
@@ -2828,7 +2828,7 @@ fsp_err_t R_USB_PipeStop (usb_ctrl_t * const p_api_ctrl, uint8_t pipe_number)
 }
 
 /**************************************************************************//**
- * @brief Gets the selected pipe number (number of the pipe that has completed initalization) via bit map information.
+ * @brief Gets the selected pipe number (number of the pipe that has completed initialization) via bit map information.
  *
  * The bit map information is stored in the area specified in argument (p_pipe).
  * Based on the information (module member and address member) assigned to the usb_ctrl_t structure,

--- a/ra/fsp/src/r_usb_basic/src/driver/r_usb_cstd_rtos.c
+++ b/ra/fsp/src/r_usb_basic/src/driver/r_usb_cstd_rtos.c
@@ -2172,7 +2172,7 @@ void usb_cstd_pipe0_msg_re_forward (uint16_t ip_no)
 
 /******************************************************************************
  * Function Name   : usb_cstd_pipe_msg_forward
- * Description     : Message foward to PIPE Transfer wait que.
+ * Description     : Message forward to PIPE Transfer wait que.
  * Arguments       : usb_utr_t *ptr       : Pointer to usb_utr_t structure.
  *               : uint16_t  pipe_no    : Pipe no.
  * Return          : none
@@ -2199,7 +2199,7 @@ void usb_cstd_pipe_msg_forward (usb_utr_t * ptr, uint16_t pipe_no)
 
 /******************************************************************************
  * Function Name   : usb_cstd_pipe0_msg_forward
- * Description     : Message foward to PIPE0 Transfer wait que.
+ * Description     : Message forward to PIPE0 Transfer wait que.
  * Arguments       : usb_utr_t *ptr       : Pointer to usb_utr_t structure.
  *               : uint16_t  dev_addr   : device address
  * Return          : none

--- a/ra/fsp/src/r_usb_basic/src/driver/r_usb_hdriver.c
+++ b/ra/fsp/src/r_usb_basic/src/driver/r_usb_hdriver.c
@@ -97,7 +97,7 @@
  * Macro definitions
  **********************************************************************************************************************/
  #if USB_CFG_COMPLIANCE == USB_CFG_ENABLE
-  #define USB_RESPONCE_COUNTER_VALUE    (6000U)
+  #define USB_RESPONSE_COUNTER_VALUE    (6000U)
  #endif                                /* USB_CFG_COMPLIANCE == USB_CFG_ENABLE */
 
  #if defined(USB_CFG_HVND_USE)
@@ -1134,7 +1134,7 @@ static void usb_hstd_interrupt (usb_utr_t * ptr)
         {
  #if USB_CFG_COMPLIANCE == USB_CFG_ENABLE
             g_usb_hstd_response_counter[ptr->ip]++;
-            if (USB_RESPONCE_COUNTER_VALUE == g_usb_hstd_response_counter[ptr->ip])
+            if (USB_RESPONSE_COUNTER_VALUE == g_usb_hstd_response_counter[ptr->ip])
             {
                 hw_usb_clear_enb_sofe(ptr);
                 disp_param.status = USB_COMPLIANCETEST_NORES;

--- a/ra/fsp/src/r_usb_basic/src/driver/r_usb_hhubsys.c
+++ b/ra/fsp/src/r_usb_basic/src/driver/r_usb_hhubsys.c
@@ -2667,7 +2667,7 @@ static uint16_t usb_hhub_request_result (uint16_t errcheck)
 
 /******************************************************************************
  * Function Name   : usb_hhub_trans_complete
- * Description     : Recieve complete Hub and Port Status Change Bitmap
+ * Description     : Receive complete Hub and Port Status Change Bitmap
  * Arguments       : usb_utr_t    *mess   : Pointer to usb_utr_t structure.
  *               : uint16_t     data1   : Not used.
  *               : uint16_t     data2   : Not used.

--- a/ra/fsp/src/r_usb_basic/src/driver/r_usb_hlibusbip.c
+++ b/ra/fsp/src/r_usb_basic/src/driver/r_usb_hlibusbip.c
@@ -897,7 +897,7 @@ uint16_t usb_hstd_read_data (usb_utr_t * ptr, uint16_t pipe, uint16_t pipemode)
     }
     else
     {
-        /* Continus Receive data */
+        /* Continues Receive data */
         count    = dtln;
         end_flag = USB_READING;
         if ((0 == count) || (0 != (count % mxps)))

--- a/ra/fsp/src/r_usb_hhid/src/r_usb_hhid_driver.c
+++ b/ra/fsp/src/r_usb_hhid/src/r_usb_hhid_driver.c
@@ -347,7 +347,7 @@ void usb_hhid_task (usb_vp_int_t stacd)
  * Arguments       : usb_utr_t *mess         : Pointer to usb_utr_t structure.
  *                 : uint8_t *table          : Descriptor store address
  *                 : uint16_t speed          : Conect Dpeed(Hi/Full/...)
- *                 : uint16_t length         : Descriptor total lenght
+ *                 : uint16_t length         : Descriptor total length
  * Return value    : uint16_t                : Error info
  ******************************************************************************/
 uint16_t usb_hhid_pipe_info (usb_utr_t * ptr, uint8_t * table, uint16_t speed, uint16_t length)

--- a/ra/fsp/src/r_usb_hmsc/src/r_usb_hmsc_driver.c
+++ b/ra/fsp/src/r_usb_hmsc/src/r_usb_hmsc_driver.c
@@ -3538,7 +3538,7 @@ usb_er_t usb_hmsc_get_max_unit (usb_utr_t * ptr, uint16_t addr, uint8_t * buff, 
     get_max_lun_table.setup.request_length = 0x0001;
     get_max_lun_table.address              = addr;
 
-    /* Recieve MaxLUN */
+    /* Receive MaxLUN */
     g_usb_hmsc_class_control[ptr->ip].keyword   = USB_PIPE0;
     g_usb_hmsc_class_control[ptr->ip].p_tranadr = buff;
     g_usb_hmsc_class_control[ptr->ip].tranlen   = get_max_lun_table.setup.request_length;
@@ -3859,7 +3859,7 @@ uint16_t usb_hmsc_mode_select10 (usb_utr_t * ptr, uint16_t side, uint8_t * buff)
 /******************************************************************************
  * Function Name   : usb_hmsc_get_dev_sts
  * Description     : Responds to HMSCD operation state
- * Arugments       : uint16_t     side    : Drive number
+ * Arguments       : uint16_t     side    : Drive number
  * Return value    : uint16_t :
  ******************************************************************************/
 uint16_t usb_hmsc_get_dev_sts (uint16_t side)
@@ -3918,7 +3918,7 @@ uint16_t usb_hmsc_alloc_drvno (uint16_t devadr)
 /******************************************************************************
  * Function Name   : usb_hmsc_free_drvno
  * Description     : Release Drive no.
- * Arugments       : uint16_t     side    : Drive number
+ * Arguments       : uint16_t     side    : Drive number
  * Return value    : result
  ******************************************************************************/
 uint16_t usb_hmsc_free_drvno (uint16_t side)

--- a/ra/fsp/src/r_usb_pmsc/src/inc/r_usb_pmsc.h
+++ b/ra/fsp/src/r_usb_pmsc/src/inc/r_usb_pmsc.h
@@ -68,19 +68,19 @@ typedef enum
 {
     USB_MSC_DNXX = 0x10,               /* Device No Data */
     USB_MSC_DIXX = 0x20,               /* Device Send(IN) Data */
-    USB_MSC_DOXX = 0x30,               /* Device Recieved(OUT) Data */
+    USB_MSC_DOXX = 0x30,               /* Device Received(OUT) Data */
     USB_MSC_XXHN = 0x01,               /* Host No Data */
-    USB_MSC_XXHI = 0x02,               /* Host Recieved(IN) Data */
+    USB_MSC_XXHI = 0x02,               /* Host Received(IN) Data */
     USB_MSC_XXHO = 0x03,               /* Host Send(OUT) Data */
     USB_MSC_DNHN = 0x11,               /* Device No Data & Host No Data */
-    USB_MSC_DNHI = 0x12,               /* Device No Data & Host Recieved(IN) Data */
+    USB_MSC_DNHI = 0x12,               /* Device No Data & Host Received(IN) Data */
     USB_MSC_DNHO = 0x13,               /* Device No Data & Host Send(OUT) Data */
     USB_MSC_DIHN = 0x21,               /* Device Send(IN) Data & Host No Data */
-    USB_MSC_DIHI = 0x22,               /* Device Send(IN) Data & Host Recieved(IN) Data */
+    USB_MSC_DIHI = 0x22,               /* Device Send(IN) Data & Host Received(IN) Data */
     USB_MSC_DIHO = 0x23,               /* Device Send(IN) Data & Host Send(OUT) Data */
-    USB_MSC_DOHN = 0x31,               /* Device Recieved(OUT) Data & Host No Data */
-    USB_MSC_DOHI = 0x32,               /* Device Recieved(OUT) Data & Host Recieved(IN) Data */
-    USB_MSC_DOHO = 0x33,               /* Device Recieved(OUT) Data & Host Send(OUT) Data */
+    USB_MSC_DOHN = 0x31,               /* Device Received(OUT) Data & Host No Data */
+    USB_MSC_DOHI = 0x32,               /* Device Received(OUT) Data & Host Received(IN) Data */
+    USB_MSC_DOHO = 0x33,               /* Device Received(OUT) Data & Host Send(OUT) Data */
 } usb_gpmsc_case13check_t;
 
 /* USB Mass Storage Devie Class Lapper check. */

--- a/ra/fsp/src/r_usb_pmsc/src/r_usb_atapi_driver.c
+++ b/ra/fsp/src/r_usb_pmsc/src/r_usb_atapi_driver.c
@@ -137,8 +137,8 @@ static const uint8_t g_usb_atapi_rs_tbl[USB_ATAPI_REQUEST_SENSE_SIZE] =
     0x00,                              /* [9]Vendor Specific */
     0x00,                              /* [10]Vendor Specific */
     0x00,                              /* [11]Vendor Specific */
-    0x24,                              /* [12]ASC(Additonal Sense Code(Mandatory)) */
-    0x00,                              /* [13]ASCQ(Additonal Sense Code Qualifier(Mandatory)) */
+    0x24,                              /* [12]ASC(Additional Sense Code(Mandatory)) */
+    0x00,                              /* [13]ASCQ(Additional Sense Code Qualifier(Mandatory)) */
     0x00,                              /* [14]Field Replaceable Unit Code(Optional) */
     0x00,                              /* [15]b7:SKSV(Sense-Key Specific Valid),b6-b0:Sense-Key Specific */
     0x00,                              /* [16]Sense-Key Specific */
@@ -835,7 +835,7 @@ void pmsc_atapi_command_processing (uint8_t * cbw, uint16_t usb_result, usb_cb_t
                     }
                     else
                     {
-                        /* All data in Device recieved */
+                        /* All data in Device received */
                         if (g_usb_pmsc_dtl == g_usb_pmsc_message.ul_size)
                         {
                             /* case 12 */

--- a/ra/fsp/src/r_usb_pmsc/src/r_usb_pmsc_driver.c
+++ b/ra/fsp/src/r_usb_pmsc/src/r_usb_pmsc_driver.c
@@ -676,7 +676,7 @@ static uint8_t usb_pmsc_check_case13 (uint32_t ul_size, uint8_t * uc_case)
     }
     else if (0 != g_usb_pmsc_cbw.bmcbw_flags.cbw_dir)
     {
-        (*uc_case) |= (uint8_t) USB_MSC_XXHI; /* Host Recieved(IN) Data */
+        (*uc_case) |= (uint8_t) USB_MSC_XXHI; /* Host Received(IN) Data */
     }
     else
     {
@@ -693,7 +693,7 @@ static uint8_t usb_pmsc_check_case13 (uint32_t ul_size, uint8_t * uc_case)
             break;
         }
 
-        case USB_MSC_DNHI:             /* Device No Data & Host Recieved(IN) Data */
+        case USB_MSC_DNHI:             /* Device No Data & Host Received(IN) Data */
         {
             result = USB_MSC_CASE04;
 
@@ -714,7 +714,7 @@ static uint8_t usb_pmsc_check_case13 (uint32_t ul_size, uint8_t * uc_case)
             break;
         }
 
-        case USB_MSC_DIHI:             /* Device Send(IN) Data & Host Recieved(IN) Data */
+        case USB_MSC_DIHI:             /* Device Send(IN) Data & Host Received(IN) Data */
         {
             if (g_usb_pmsc_dtl > ul_size)
             {
@@ -742,21 +742,21 @@ static uint8_t usb_pmsc_check_case13 (uint32_t ul_size, uint8_t * uc_case)
             break;
         }
 
-        case USB_MSC_DOHN:             /* Device Recieved(OUT) Data & Host No Data */
+        case USB_MSC_DOHN:             /* Device Received(OUT) Data & Host No Data */
         {
             result = USB_MSC_CASE03;
 
             break;
         }
 
-        case USB_MSC_DOHI:             /* Device Recieved(OUT) Data & Host Recieved(IN) Data */
+        case USB_MSC_DOHI:             /* Device Received(OUT) Data & Host Received(IN) Data */
         {
             result = USB_MSC_CASE08;
 
             break;
         }
 
-        case USB_MSC_DOHO:             /* Device Recieved(OUT) Data & Host Send(OUT) Data */
+        case USB_MSC_DOHO:             /* Device Received(OUT) Data & Host Send(OUT) Data */
         {
             if (g_usb_pmsc_dtl > ul_size)
             {

--- a/ra/fsp/src/rm_ble_abs/rm_ble_abs.c
+++ b/ra/fsp/src/rm_ble_abs/rm_ble_abs.c
@@ -252,20 +252,20 @@
 
 #define BLE_ABS_SECURE_DATA_BONDING_NUMBER_OFFSET               BLE_ABS_SECURE_DATA_MAGIC_NUMBER_SIZE
 #define BLE_ABS_SECURE_DATA_OUT_BONDING_OFFSET                  (5)
-#define BLE_ABS_SECURE_DATA_SECURITY_INFOMATION_OFFSET          (8)
-#define BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFOMATION_OFFSET     (12)
+#define BLE_ABS_SECURE_DATA_SECURITY_INFORMATION_OFFSET          (8)
+#define BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFORMATION_OFFSET     (12)
 #define BLE_ABS_SECURE_DATA_SECURITY_KEYS_OFFSET                (20)
 #define BLE_ABS_SECURE_DATA_SECURITY_REMOTE_OFFSET              (48)
 #define BLE_ABS_SECURE_DATA_SECURITY_IDENTITY_ADDRESS_OFFSET    (62)
 
 #define BLE_ABS_SECURE_DATA_REMOTE_BONDING_SIZE                 (88)
 #define BLE_ABS_SECURE_DATA_LOCAL_AREA_SIZE                     (40)
-#define BLE_ABS_SECURE_DATA_LOCAL_INFOMATION_SIZE               (1)
+#define BLE_ABS_SECURE_DATA_LOCAL_INFORMATION_SIZE               (1)
 #define BLE_ABS_SECURE_DATA_BLUETOOTH_DEVICE_ADDRESS_SIZE       (7)
 #define BLE_ABS_SECURE_DATA_MANEGEMENT_DATA_SIZE                (8)
 #define BLE_ABS_SECURE_DATA_REMOTE_KEY_ATTRIBUTE_SIZE           (6)
 #define BLE_ABS_SECURE_DATA_REMOTE_KEYS_SIZE                    (65)
-#define BLE_ABS_SECURE_DATA_REMOTE_KEYS_INFOMATION_SIZE         (4)
+#define BLE_ABS_SECURE_DATA_REMOTE_KEYS_INFORMATION_SIZE         (4)
 
 #define BLE_ABS_SECURE_DATA_BASE_ADDR                           (BLE_ABS_SECURE_DATA_BLOCK_BASE +           \
                                                                  (BLE_ABS_CFG_SECURE_DATA_DATAFLASH_BLOCK * \
@@ -281,7 +281,7 @@
 #define BLE_ABS_SECURE_DATA_ADDR_LOC_INFO                       (BLE_ABS_SECURE_DATA_ADDR_LOC_IDADDR + \
                                                                  BLE_ABS_SECURE_DATA_BLUETOOTH_DEVICE_ADDRESS_SIZE)
 #define BLE_ABS_SECURE_DATA_ADDR_REM_START                      (BLE_ABS_SECURE_DATA_ADDR_LOC_INFO + \
-                                                                 BLE_ABS_SECURE_DATA_LOCAL_INFOMATION_SIZE)
+                                                                 BLE_ABS_SECURE_DATA_LOCAL_INFORMATION_SIZE)
 #define BLE_ABS_SECURE_DATA_MAX_SIZE                            (BLE_ABS_SECURE_DATA_SECURITY_REMOTE_OFFSET + \
                                                                  BLE_ABS_SECURE_DATA_REMOTE_BONDING_SIZE *    \
                                                                  BLE_ABS_CFG_NUMBER_BONDING)
@@ -2568,7 +2568,7 @@ static fsp_err_t ble_abs_advertising_report_handler (ble_abs_instance_ctrl_t * c
             while (pos < len)
             {
                 /* Each advertising structure have following constructs.
-                 * - Lenght: 1 byte (The length of AD type + AD data)
+                 * - Length: 1 byte (The length of AD type + AD data)
                  * - AD type: 1 byte
                  * - AD data: variable
                  */
@@ -3741,7 +3741,7 @@ static fsp_err_t ble_abs_secure_data_writeremkeys (flash_instance_t const * p_in
 
     gs_key_ex_param.p_keys_info = (st_ble_gap_key_dist_t *) (start_addr + BLE_ABS_SECURE_DATA_SECURITY_KEYS_OFFSET); ///< ex_key_param
     memcpy(&p_sec_data[BLE_ABS_SECURE_DATA_SECURITY_REMOTE_OFFSET + entry * BLE_ABS_SECURE_DATA_REMOTE_BONDING_SIZE +
-                       BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFOMATION_OFFSET],
+                       BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFORMATION_OFFSET],
            (uint8_t *) &gs_key_ex_param,
            BLE_ABS_SECURE_DATA_REMOTE_KEY_ATTRIBUTE_SIZE);
 
@@ -3751,9 +3751,9 @@ static fsp_err_t ble_abs_secure_data_writeremkeys (flash_instance_t const * p_in
            BLE_ABS_SECURE_DATA_REMOTE_KEYS_SIZE); ///< keys
 
     memcpy(&p_sec_data[BLE_ABS_SECURE_DATA_SECURITY_REMOTE_OFFSET + entry * BLE_ABS_SECURE_DATA_REMOTE_BONDING_SIZE +
-                       BLE_ABS_SECURE_DATA_SECURITY_INFOMATION_OFFSET],
+                       BLE_ABS_SECURE_DATA_SECURITY_INFORMATION_OFFSET],
            (uint8_t *) p_keyinfo,
-           BLE_ABS_SECURE_DATA_REMOTE_KEYS_INFOMATION_SIZE);                                ///< keyinfo
+           BLE_ABS_SECURE_DATA_REMOTE_KEYS_INFORMATION_SIZE);                                ///< keyinfo
 
     ble_abs_secure_data_update_bond_num(p_instance, entry, op_code, &bond_num, p_sec_data); ///< update bond order and the number of bonds.
 
@@ -4084,9 +4084,9 @@ static fsp_err_t ble_abs_secure_data_read_bond_info (flash_instance_t const * p_
                      BLE_ABS_SECURE_DATA_REMOTE_BONDING_SIZE;
         p_bond_info[i].p_addr      = (st_ble_dev_addr_t *) (p_bonds + start_addr);
         p_bond_info[i].p_auth_info =
-            (st_ble_gap_auth_info_t *) (p_bonds + start_addr + BLE_ABS_SECURE_DATA_SECURITY_INFOMATION_OFFSET);
+            (st_ble_gap_auth_info_t *) (p_bonds + start_addr + BLE_ABS_SECURE_DATA_SECURITY_INFORMATION_OFFSET);
         p_bond_info[i].p_keys =
-            (st_ble_gap_key_ex_param_t *) (p_bonds + start_addr + BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFOMATION_OFFSET);
+            (st_ble_gap_key_ex_param_t *) (p_bonds + start_addr + BLE_ABS_SECURE_DATA_SECURITY_KEYS_INFORMATION_OFFSET);
         p_bond_info[i].p_keys->p_keys_info =
             (st_ble_gap_key_dist_t *) (p_bonds + start_addr + BLE_ABS_SECURE_DATA_SECURITY_KEYS_OFFSET);
         (*p_out_bond_num)++;

--- a/ra/fsp/src/rm_ble_abs_gtl/rm_ble_abs_gtl.c
+++ b/ra/fsp/src/rm_ble_abs_gtl/rm_ble_abs_gtl.c
@@ -388,7 +388,7 @@ fsp_err_t RM_BLE_ABS_StartLegacyAdvertising (ble_abs_ctrl_t * const             
 
     if ((NULL != p_advertising_parameter->p_advertising_data) && (0 < p_advertising_parameter->advertising_data_length))
     {
-        /* Configure the GAP Advertisment Payload. */
+        /* Configure the GAP Advertisement Payload. */
         st_ble_gap_adv_data_t advertising_data = {0};
         advertising_data.data_type   = (uint8_t) (BLE_GAP_ADV_DATA_MODE);
         advertising_data.data_length = p_advertising_parameter->advertising_data_length;
@@ -407,10 +407,10 @@ fsp_err_t RM_BLE_ABS_StartLegacyAdvertising (ble_abs_ctrl_t * const             
         FSP_ERROR_RETURN(BLE_SUCCESS == R_BLE_GAP_SetAdvSresData(&advertising_data), FSP_ERR_INVALID_ARGUMENT);
     }
 
-    /* Start Legacy Advertisment. */
+    /* Start Legacy Advertisement. */
     FSP_ERROR_RETURN(BLE_SUCCESS == R_BLE_GAP_StartAdv(0, 0, 0), FSP_ERR_INVALID_ARGUMENT);
 
-    /* Set the internal status flags to indicate the advertisment mode. */
+    /* Set the internal status flags to indicate the advertisement mode. */
     uint32_t status =
         p_advertising_parameter->fast_advertising_period ? BLE_ABS_ADV_STATUS_PARAM_FAST : BLE_ABS_ADV_STATUS_PARAM_SLOW;
     ble_abs_set_advertising_status(p_instance_ctrl, advertising_handle, status, 0);
@@ -992,7 +992,7 @@ static fsp_err_t ble_abs_advertising_report_handler (ble_abs_instance_ctrl_t * c
             while (pos < len)
             {
                 /* Each advertising structure have following constructs.
-                 * - Lenght: 1 byte (The length of AD type + AD data)
+                 * - Length: 1 byte (The length of AD type + AD data)
                  * - AD type: 1 byte
                  * - AD data: variable
                  */

--- a/ra/fsp/src/rm_ble_abs_spp/rm_ble_abs_spp.c
+++ b/ra/fsp/src/rm_ble_abs_spp/rm_ble_abs_spp.c
@@ -406,7 +406,7 @@ fsp_err_t RM_BLE_ABS_StartLegacyAdvertising (ble_abs_ctrl_t * const             
 
     if ((NULL != p_advertising_parameter->p_advertising_data) && (0 < p_advertising_parameter->advertising_data_length))
     {
-        /* Configure the GAP Advertisment Payload. */
+        /* Configure the GAP Advertisement Payload. */
         st_ble_gap_adv_data_t advertising_data = {0};
         advertising_data.data_type   = (uint8_t) (BLE_GAP_ADV_DATA_MODE);
         advertising_data.data_length = p_advertising_parameter->advertising_data_length;
@@ -425,10 +425,10 @@ fsp_err_t RM_BLE_ABS_StartLegacyAdvertising (ble_abs_ctrl_t * const             
         FSP_ERROR_RETURN(BLE_SUCCESS == R_BLE_GAP_SetAdvSresData(&advertising_data), FSP_ERR_INVALID_ARGUMENT);
     }
 
-    /* Start Legacy Advertisment. */
+    /* Start Legacy Advertisement. */
     FSP_ERROR_RETURN(BLE_SUCCESS == R_BLE_GAP_StartAdv(0, 0, 0), FSP_ERR_INVALID_ARGUMENT);
 
-    /* Set the internal status flags to indicate the advertisment mode. */
+    /* Set the internal status flags to indicate the advertisement mode. */
     uint32_t status =
         p_advertising_parameter->fast_advertising_period ? BLE_ABS_ADV_STATUS_PARAM_FAST : BLE_ABS_ADV_STATUS_PARAM_SLOW;
     ble_abs_set_advertising_status(p_instance_ctrl, advertising_handle, status, 0);
@@ -1010,7 +1010,7 @@ static fsp_err_t ble_abs_advertising_report_handler (ble_abs_instance_ctrl_t * c
             while (pos < len)
             {
                 /* Each advertising structure have following constructs.
-                 * - Lenght: 1 byte (The length of AD type + AD data)
+                 * - Length: 1 byte (The length of AD type + AD data)
                  * - AD type: 1 byte
                  * - AD data: variable
                  */

--- a/ra/fsp/src/rm_block_media_spi/rm_block_media_spi.c
+++ b/ra/fsp/src/rm_block_media_spi/rm_block_media_spi.c
@@ -449,7 +449,7 @@ fsp_err_t RM_BLOCK_MEDIA_SPI_Erase (rm_block_media_ctrl_t * const p_ctrl,
         iteration--;
     }
 
-    /* Notify appication of completion */
+    /* Notify application of completion */
     p_instance_ctrl->erase_in_progress = false;
     rm_block_media_event_t event =
         (FSP_SUCCESS == err ? RM_BLOCK_MEDIA_EVENT_OPERATION_COMPLETE : RM_BLOCK_MEDIA_EVENT_ERROR);
@@ -508,7 +508,7 @@ static fsp_err_t rm_block_media_spi_program (rm_block_media_spi_instance_ctrl_t 
         iteration--;
     }
 
-    /* Notify appication of completion */
+    /* Notify application of completion */
     p_instance_ctrl->write_in_progress = false;
     rm_block_media_event_t event =
         (FSP_SUCCESS == err ? RM_BLOCK_MEDIA_EVENT_OPERATION_COMPLETE : RM_BLOCK_MEDIA_EVENT_ERROR);

--- a/ra/fsp/src/rm_cellular_ryz_aws/cellular_ryz.c
+++ b/ra/fsp/src/rm_cellular_ryz_aws/cellular_ryz.c
@@ -178,7 +178,7 @@ CellularError_t Cellular_ModuleEnableUrc (CellularContext_t * pContext)
  * @param[in] pAtReq    Pointer to AT request
  *
  * @retval  CELLULAR_SUCCESS        AT command succeeded
- * @retval  CELLULAR_BAD_PARAMETER  Bad paramter passed in
+ * @retval  CELLULAR_BAD_PARAMETER  Bad parameter passed in
  **********************************************************************************************************************/
 static CellularError_t sendAtCommandWithRetryTimeout (CellularContext_t * pContext, const CellularAtReq_t * pAtReq)
 {

--- a/ra/fsp/src/rm_cellular_ryz_aws/cellular_ryz_api.c
+++ b/ra/fsp/src/rm_cellular_ryz_aws/cellular_ryz_api.c
@@ -250,7 +250,7 @@ CellularError_t Cellular_GetSimCardInfo (CellularHandle_t cellularHandle, Cellul
     atReqGetImsi.pData        = pSimCardInfo->imsi;
     atReqGetImsi.dataLen      = CELLULAR_IMSI_MAX_SIZE + 1U;
 
-    atReqGetHplmn.pAtCmd       = "AT+CRSM=176,28514,0,0,0"; /* READ BINARY commmand. HPLMN Selector with Access Technology( 6F62 ). */
+    atReqGetHplmn.pAtCmd       = "AT+CRSM=176,28514,0,0,0"; /* READ BINARY command. HPLMN Selector with Access Technology( 6F62 ). */
     atReqGetHplmn.atCmdType    = CELLULAR_AT_WITH_PREFIX;
     atReqGetHplmn.pAtRspPrefix = "+CRSM";
     atReqGetHplmn.respCallback = _Cellular_RecvFuncGetHplmn;

--- a/ra/fsp/src/rm_comms_lock/rm_comms_lock.h
+++ b/ra/fsp/src/rm_comms_lock/rm_comms_lock.h
@@ -76,7 +76,7 @@ typedef struct st_rm_comms_semaphore
 /**********************************************************************************************************************
  * @brief rm_comms_lock API
  *
- * @retval FSP_SUCCESS              Funciton call succeeds.
+ * @retval FSP_SUCCESS              Function call succeeds.
  * @retval FSP_ERR_INTERNAL         RTOS internal error.
  * @retval FSP_ERR_UNSUPPORTED      RTOS not supported.
  *********************************************************************************************************************/

--- a/ra/fsp/src/rm_emwin_port/GUI_X_OS.c
+++ b/ra/fsp/src/rm_emwin_port/GUI_X_OS.c
@@ -54,7 +54,7 @@ static volatile uint32_t g_gui_time_ms = 0;
  *                 GUI_Delay(int)
  *
  * Some timing dependent routines require a GetTime
- * and delay funtion. Default time unit (tick), normally is
+ * and delay function. Default time unit (tick), normally is
  * 1 ms.
  */
 #if EMWIN_CFG_RTOS == 0                // No RTOS

--- a/ra/fsp/src/rm_filex_block_media/rm_filex_block_media.c
+++ b/ra/fsp/src/rm_filex_block_media/rm_filex_block_media.c
@@ -203,7 +203,7 @@ void RM_FILEX_BLOCK_MEDIA_BlockDriver (FX_MEDIA * p_fx_media)
  * @retval     FSP_SUCCESS                 Driver request fulfilled.
  * @retval     FSP_ERR_MEDIA_OPEN_FAILED   Not a valid boot record or partition table
  * @retval     FSP_ERR_UNSUPPORTED         Requested FileX command is not supported
- * @retval     FSP_ERR_INTERNAL            An error has occured with the lower level block media driver
+ * @retval     FSP_ERR_INTERNAL            An error has occurred with the lower level block media driver
  *
  * @return See @ref RENESAS_ERROR_CODES or functions called by this function for other possible return codes.
  *         This function calls:

--- a/ra/fsp/src/rm_freertos_plus_tcp/NetworkInterface.c
+++ b/ra/fsp/src/rm_freertos_plus_tcp/NetworkInterface.c
@@ -322,7 +322,7 @@ __attribute__((weak)) BaseType_t xApplicationGetRandomNumber (uint32_t * pulNumb
 {
     /* example of a 32-bit random number generator.
      * rand() in returns a 16-bit number. so create 32 bit Random number using 16 bit rand().
-     * In this case just a psuedo random number is used so THIS IS NOT RECOMMENDED FOR PRODUCTION SYSTEMS.
+     * In this case just a pseudo random number is used so THIS IS NOT RECOMMENDED FOR PRODUCTION SYSTEMS.
      */
     uint32_t ulRandomValue = 0;
 
@@ -341,7 +341,7 @@ BSP_WEAK_REFERENCE uint32_t ulApplicationGetNextSequenceNumber (uint32_t ulSourc
 {
     /*
      * Callback that provides the inputs necessary to generate a randomized TCP
-     * Initial Sequence Number per RFC 6528.  In this case just a psuedo random
+     * Initial Sequence Number per RFC 6528.  In this case just a pseudo random
      * number is used so THIS IS NOT RECOMMENDED FOR PRODUCTION SYSTEMS.
      */
     FSP_PARAMETER_NOT_USED(ulSourceAddress);

--- a/ra/fsp/src/rm_motor_120_degree/rm_motor_120_degree.c
+++ b/ra/fsp/src/rm_motor_120_degree/rm_motor_120_degree.c
@@ -329,7 +329,7 @@ fsp_err_t RM_MOTOR_120_DEGREE_Stop (motor_ctrl_t * const p_ctrl)
  * Example:
  * @snippet rm_motor_120_degree_example.c RM_MOTOR_120_DEGREE_ErrorSet
  *
- * @retval FSP_SUCCESS              Successfully set error infomation.
+ * @retval FSP_SUCCESS              Successfully set error information.
  * @retval FSP_ERR_ASSERTION        p_ctrl is NULL.
  * @retval FSP_ERR_NOT_OPEN         Module is not open.
  *

--- a/ra/fsp/src/rm_motor_inertia_estimate/rm_motor_inertia_estimate.c
+++ b/ra/fsp/src/rm_motor_inertia_estimate/rm_motor_inertia_estimate.c
@@ -620,7 +620,7 @@ static void rm_motor_inertia_estimate_speed_cyclic (motor_inertia_estimate_ctrl_
 
 /***********************************************************************************************************************
  * Function Name : rm_motor_inertia_estimate_steady_process
- * Description   : Process at positon control in steady state (reached to reference position)
+ * Description   : Process at position control in steady state (reached to reference position)
  * Arguments     : p_ctrl - pointer of module data
  * Return Value  : None
  **********************************************************************************************************************/
@@ -767,7 +767,7 @@ static void rm_motor_inertia_estimate_steady_process (motor_inertia_estimate_ins
 
 /***********************************************************************************************************************
  * Function Name : rm_motor_inertia_estimate_transition_process
- * Description   : Process at positon control in transition state
+ * Description   : Process at position control in transition state
  * Arguments     : p_ctrl - pointer of module data
  * Return Value  : None
  **********************************************************************************************************************/

--- a/ra/fsp/src/rm_motor_return_origin/rm_motor_return_origin.c
+++ b/ra/fsp/src/rm_motor_return_origin/rm_motor_return_origin.c
@@ -53,7 +53,7 @@ static void  rm_motor_return_origin_initialize(motor_return_origin_instance_ctrl
 static void  rm_motor_return_origin_speed_cyclic(motor_return_origin_instance_ctrl_t * const p_ctrl);
 static float rm_motor_return_origin_push(motor_return_origin_instance_ctrl_t * const p_ctrl);
 static float rm_motor_return_origin_calculate_search_speed_accel(motor_return_origin_instance_ctrl_t * p_ctrl);
-static float rm_motor_return_origin_calculate_search_speed_decleration(motor_return_origin_instance_ctrl_t * p_ctrl);
+static float rm_motor_return_origin_calculate_search_speed_declaration(motor_return_origin_instance_ctrl_t * p_ctrl);
 static float rm_motor_return_origin_calc_decele_rad(float f4_move_pos, float f4_speed, float f4_acc);
 
 /***********************************************************************************************************************
@@ -583,7 +583,7 @@ static float rm_motor_return_origin_push (motor_return_origin_instance_ctrl_t * 
         case MOTOR_RETURN_ORIGIN_STATE_DECELERATE:
         {
             f_calculated_ref_position -=
-                (float) p_ctrl->s1_direction * rm_motor_return_origin_calculate_search_speed_decleration(p_ctrl) *
+                (float) p_ctrl->s1_direction * rm_motor_return_origin_calculate_search_speed_declaration(p_ctrl) *
                 MOTOR_RETURN_ORIGIN_RAD_TO_DEGREE;
             if ((p_ctrl->f_current_speed > 0.0F) || (p_ctrl->f_current_speed < 0.0F))
             {
@@ -621,12 +621,12 @@ static float rm_motor_return_origin_calculate_search_speed_accel (motor_return_o
 }                                      /* End of function rm_motor_return_origin_calculate_search_speed_accel */
 
 /***********************************************************************************************************************
- * Function Name: rm_motor_return_origin_calculate_search_speed_decleration
+ * Function Name: rm_motor_return_origin_calculate_search_speed_declaration
  * Description  : Speed calculation during deceleration
  * Arguments    : p_ctrl - pointer of module data
  * Return Value : speed[rad / sample time] ,absolute value.
  ***********************************************************************************************************************/
-static float rm_motor_return_origin_calculate_search_speed_decleration (motor_return_origin_instance_ctrl_t * p_ctrl)
+static float rm_motor_return_origin_calculate_search_speed_declaration (motor_return_origin_instance_ctrl_t * p_ctrl)
 {
     p_ctrl->f_current_speed -= p_ctrl->f_accel_speed;
     if (p_ctrl->f_current_speed <= 0.0F)
@@ -635,7 +635,7 @@ static float rm_motor_return_origin_calculate_search_speed_decleration (motor_re
     }
 
     return p_ctrl->f_current_speed;
-}                                      /* End of function rm_motor_return_origin_calculate_search_speed_decleration */
+}                                      /* End of function rm_motor_return_origin_calculate_search_speed_declaration */
 
 /***********************************************************************************************************************
  * Function Name: rm_motor_return_origin_calc_decele_rad

--- a/ra/fsp/src/rm_motor_sense_hall/rm_motor_sense_hall.c
+++ b/ra/fsp/src/rm_motor_sense_hall/rm_motor_sense_hall.c
@@ -258,7 +258,7 @@ fsp_err_t RM_MOTOR_SENSE_HALL_AngleSpeedGet (motor_angle_ctrl_t * const p_ctrl,
 
     FSP_PARAMETER_NOT_USED(p_phase_err);
 
-    /* Position aquisition (hall sensor) */
+    /* Position acquisition (hall sensor) */
     p_instance_ctrl->u1_last_hall_signal = p_instance_ctrl->u1_hall_signal;
 
     u4_temp_level = R_BSP_PinRead(p_extended_cfg->port_hall_sensor_u);

--- a/ra/fsp/src/rm_motor_sense_induction/rm_motor_sense_induction.c
+++ b/ra/fsp/src/rm_motor_sense_induction/rm_motor_sense_induction.c
@@ -1104,7 +1104,7 @@ static void rm_motor_sense_induction_correction_sequence (motor_sense_induction_
 
             if (p_ctrl->u2_signal_maximum_difference < p_extended_cfg->u2_signal_error_limit)
             {
-                /* Finish the error correction process normaly */
+                /* Finish the error correction process normally */
                 p_ctrl->u1_correct_status      = MOTOR_SENSE_INDUCTION_CORRECT_FINISH;
                 p_ctrl->u1_angle_adjust_status = MOTOR_SENSE_ENCODER_ANGLE_ADJUST_FINISH;
             }
@@ -1485,7 +1485,7 @@ static void rm_motor_sense_induction_get_data_phase_calibration (motor_sense_ind
             f4_sens_sin_adc = (f4_sens_sin_adc * p_ctrl->f_adc_scaling);
             f4_sens_cos_adc = (f4_sens_cos_adc * p_ctrl->f_adc_scaling);
 
-            /* signal correctin */
+            /* signal correction */
             f4_sens_sin_adc = (f4_sens_sin_adc - p_ctrl->f_sin_offset) * p_ctrl->f_sin_gain;
             f4_sens_cos_adc = (f4_sens_cos_adc - p_ctrl->f_cos_offset) * p_ctrl->f_cos_gain;
 

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_aes_alt.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_aes_alt.c
@@ -2424,7 +2424,7 @@ UINT    status;
         case NX_CRYPTO_SET_ADDITIONAL_DATA:
         {
 
-            /* Set additonal data pointer.  */
+            /* Set additional data pointer.  */
             ctx -> nx_crypto_aes_mode_context.ccm.nx_crypto_ccm_additional_data = (VOID *)input;
 
             /* Set additional data length.  */
@@ -2841,7 +2841,7 @@ UINT    status;
         case NX_CRYPTO_SET_ADDITIONAL_DATA:
         {
 
-            /* Set additonal data pointer.  */
+            /* Set additional data pointer.  */
             ctx -> nx_crypto_aes_mode_context.gcm.nx_crypto_gcm_additional_data = (VOID *)input;
 
             /* Set additional data length.  */

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ccm_alt.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ccm_alt.c
@@ -331,7 +331,7 @@ UCHAR  Flags = 0;
 UCHAR *A = ccm_metadata -> nx_crypto_ccm_A;
 
     /* Check the block size. */
-    /* Accroding to RFC 3610, valid values of L range between 2 octets and 8 octets, iv[0] range between 7 octets and 13 octets. */
+    /* According to RFC 3610, valid values of L range between 2 octets and 8 octets, iv[0] range between 7 octets and 13 octets. */
     if (block_size != NX_CRYPTO_CCM_BLOCK_SIZE || iv[0] > 13 || iv[0] < 7)
     {
         return(NX_CRYPTO_PTR_ERROR);

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ccm_alt_process.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ccm_alt_process.c
@@ -50,7 +50,7 @@ static UINT ccm_block_format (NX_CRYPTO_CCM * ccm_metadata, UCHAR * a_data, UINT
     USHORT M = ccm_metadata -> nx_crypto_ccm_icv_length;
 
     /* Check the block size. */
-    /* Accroding to RFC 3610, valid values of L range between 2 octets and 8 octets, iv[0] range between 7 octets and 13 octets. */
+    /* According to RFC 3610, valid values of L range between 2 octets and 8 octets, iv[0] range between 7 octets and 13 octets. */
     if (block_size != NX_CRYPTO_CCM_BLOCK_SIZE || iv[0] > 13 || iv[0] < 7)
     {
         return(NX_CRYPTO_PTR_ERROR);
@@ -125,7 +125,7 @@ UINT sce_nx_crypto_ccm_encrypt_init (NX_CRYPTO_AES * aes_ctx,
 
     /* The memory allocated by the NetX Secure stack to store the metadata is not fully 
     required for the crypto processing when sce engines are used. Thus the same space has 
-    been used to accomodate the context info of sce engines. The allocated space for 
+    been used to accommodate the context info of sce engines. The allocated space for 
     processing buffer 'nx_crypto_ccm_X' is utilized for storing the input data length 
     in big endian form */
     NX_CRYPTO_MEMSET(p_ccm_metadata->nx_crypto_ccm_X, 0, sizeof(p_ccm_metadata->nx_crypto_ccm_X));

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ec_alt.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ec_alt.c
@@ -3370,7 +3370,7 @@ NX_CRYPTO_EC_POINT    public_key;
 /*    NX_CRYPTO_HUGE_NUMBER_COPY            Copy huge number              */
 /*    NX_CRYPTO_HUGE_NUMBER_INITIALIZE      Initialize the buffer of      */
 /*                                            huge number                 */
-/*    [nx_crypto_ec_add]                    Perform addtion for EC        */
+/*    [nx_crypto_ec_add]                    Perform addition for EC        */
 /*    [nx_crypto_ec_multiple]               Perform multiplication for EC */
 /*                                                                        */
 /*  CALLED BY                                                             */

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ecdsa_alt_process.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_ecdsa_alt_process.c
@@ -174,7 +174,7 @@ UINT sce_nx_crypto_ecdsa_sign (NX_CRYPTO_EC * curve,
      * *-Any larger hash data will be truncated.
      * *-Any smaller data will be 0-padded to the LEFT.
      *//* Start after 8 bytes to prevent another memory adjustment for 224 and 192 bit curves. This will serve as 0 padding offset.
-     * The 'digest' buffer is large enough to accomadate this extra 0 padding for 224 and 192 bit curves.
+     * The 'digest' buffer is large enough to accommodate this extra 0 padding for 224 and 192 bit curves.
      * There will be no 0 padding for 256 and 384 bit curves.
      */
     uint32_t idx = (curve_size > hash_length) ? (curve_size - hash_length) : 0;
@@ -274,7 +274,7 @@ UINT sce_nx_crypto_ecdsa_verify (NX_CRYPTO_EC * curve,
     uint32_t idx = (curve_size > hash_length) ? (curve_size - hash_length) : 0;
 
     /* Start after 8 bytes to prevent another memory adjustment for 224 and 192 bit curves. This will serve as 0 padding offset.
-     * The 'digest' buffer is large enough to accomadate this extra 0 padding for 224 and 192 bit curves.
+     * The 'digest' buffer is large enough to accommodate this extra 0 padding for 224 and 192 bit curves.
      * There will be no 0 padding for 256 and 384 bit curves.
      */
     NX_CRYPTO_MEMCPY(&digest[idx + 8U], hash, hash_length);

--- a/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_gcm_alt.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/nx_crypto_gcm_alt.c
@@ -921,7 +921,7 @@ UINT i;
  *       sce_nx_crypto_gcm_decrypt_init is created here to mimic an equivalent _nx_crypto_gcm_decrypt_init.
  *       This is directly called by the _nx_crypto_method_aes_gcm_operation function when HW AES is enabled.
  *       Only GHASH and block cipher is HW accelerated due to the nature of SCE9 procedures in handling partial blocks.
- * @note Keeping this function here instead of the nx_crypto_gcm_alt_process.c to satisfy dependancy of 
+ * @note Keeping this function here instead of the nx_crypto_gcm_alt_process.c to satisfy dependency of 
  *       static function _nx_crypto_gcm_inc32.
  *
  * @retval NX_CRYPTO_SUCCESS              GCM initialization was successful.

--- a/ra/fsp/src/rm_netx_secure_crypto/rm_netx_secure_crypto.c
+++ b/ra/fsp/src/rm_netx_secure_crypto/rm_netx_secure_crypto.c
@@ -80,7 +80,7 @@ void srand (unsigned int seed)
 
 /***********************************************************************************************************************
  * ECC Key Generate helper function for ECDSA and ECDH APIs.
- * @note This fucntion must not be called directly by the user application.
+ * @note This function must not be called directly by the user application.
  * Output: (Wrapped private key || Uncompressed public key) where Uncompressed public key starts with 0x04.
  * @retval NX_CRYPTO_SUCCESS              Key generation was successful.
  * @retval NX_CRYPTO_NOT_SUCCESSFUL       Key Generation was not successful.

--- a/ra/fsp/src/rm_rai_data_collector/rm_rai_data_collector.c
+++ b/ra/fsp/src/rm_rai_data_collector/rm_rai_data_collector.c
@@ -303,7 +303,7 @@ fsp_err_t RM_RAI_DATA_COLLECTOR_SnapshotStop (rai_data_collector_ctrl_t * const 
  *
  * Implements @ref rai_data_collector_api_t::channelBufferGet().
  *
- * @retval FSP_SUCCESS              Buffer avaialble.
+ * @retval FSP_SUCCESS              Buffer available.
  * @retval FSP_ERR_ASSERTION        An input parameter was invalid.
  * @retval FSP_ERR_NOT_OPEN         Module not open.
  *

--- a/ra/fsp/src/rm_rai_data_shipper/rm_rai_data_shipper.c
+++ b/ra/fsp/src/rm_rai_data_shipper/rm_rai_data_shipper.c
@@ -134,7 +134,7 @@ fsp_err_t RM_RAI_DATA_SHIPPER_Read (rai_data_shipper_ctrl_t * const p_api_ctrl,
 }
 
 /*******************************************************************************************************************//**
- * Write data. Note this funciton may be called in ISR.
+ * Write data. Note this function may be called in ISR.
  *
  * Implements @ref rai_data_shipper_api_t::write().
  *

--- a/ra/fsp/src/rm_threadx_port/tx_initialize_low_level.c
+++ b/ra/fsp/src/rm_threadx_port/tx_initialize_low_level.c
@@ -38,7 +38,7 @@
  #define TX_PORT_CFG_SYSTICK_IPL    TX_PORT_MAX_IPL
 #endif
 
-/* Define the location of the begining of the free RAM  */
+/* Define the location of the beginning of the free RAM  */
 
 #if defined(__ARMCC_VERSION)           /* AC6 compiler */
 extern uint32_t Image$$RAM_END$$Limit;

--- a/ra/fsp/src/rm_threadx_port/tx_port.h
+++ b/ra/fsp/src/rm_threadx_port/tx_port.h
@@ -572,7 +572,7 @@ extern void    _tx_thread_secure_stack_initialize(void);
    armlink linker inlining. This requires them to consist of either a
    single 32-bit instruction, or either one or two 16-bit instructions
    followed by a "BX lr". Note that to reduce the critical region size, the
-   16-bit "CPSID i" instruction is preceeded by a 16-bit NOP */
+   16-bit "CPSID i" instruction is preceded by a 16-bit NOP */
 
 
 #ifdef TX_DISABLE_INLINE

--- a/ra/fsp/src/rm_touch/rm_touch.c
+++ b/ra/fsp/src/rm_touch/rm_touch.c
@@ -137,7 +137,7 @@
   #define TOUCH_UART_INSTANCE_MAX             (32)
 
 /* UART Receive Buffer Size */
-  #define TOUCH_UART_RECIEVE_BUF_SIZE         (13)
+  #define TOUCH_UART_RECEIVE_BUF_SIZE         (13)
 
 /* UART Command version */
   #define TOUCH_UART_VERSION_MAJOR            ((uint8_t) 0x01U)
@@ -240,7 +240,7 @@
  #endif
 
  #define TOUCH_TUNING_COMMAND_BUF_NUM     (0x2)
- #define TOUCH_TUNING_RECIEVE_BUF_SIZE    (0xF)
+ #define TOUCH_TUNING_RECEIVE_BUF_SIZE    (0xF)
  #define TOUCH_TUNING_ICOG_100            (0)                     // ICOG = 100%
  #define TOUCH_TUNING_ICOG_66             (1)                     // ICOG = 66%
  #define TOUCH_TUNING_RICOA_RECOMMEND     (0xFF)                  // ICO input current
@@ -439,7 +439,7 @@ static uint8_t g_touch_tuning_tx_buf[TOUCH_TUNING_TRANSMIT_BUF_SIZE];
 /* data transmit flag */
 volatile uint8_t g_touch_uart_transmit_flag;
 
-static uint8_t           g_touch_uart_rx_buf[TOUCH_TUNING_RECIEVE_BUF_SIZE];
+static uint8_t           g_touch_uart_rx_buf[TOUCH_TUNING_RECEIVE_BUF_SIZE];
 static uint16_t          g_touch_uart_rx_num = 0;
 static uart_instance_t * gp_touch_uart_instance;
 #endif
@@ -2457,9 +2457,9 @@ void touch_uart_callback (uart_callback_args_t * p_args)
  #if (TOUCH_CFG_UART_TUNING_SUPPORT == 1)
     touch_instance_ctrl_t * p_instance_ctrl = gp_touch_isr_context;
     uint16_t                element_id;
-    uint8_t               * port_adress_8;
-    uint16_t              * port_adress_16;
-    uint32_t              * port_adress_32;
+    uint8_t               * port_address_8;
+    uint16_t              * port_address_16;
+    uint32_t              * port_address_32;
     uint8_t                 write_byte;
  #endif
 
@@ -2489,7 +2489,7 @@ void touch_uart_callback (uart_callback_args_t * p_args)
  #if (TOUCH_CFG_MONITOR_ENABLE && (TOUCH_CFG_UART_MONITOR_SUPPORT == 1))
             case TOUCH_UART_COMMAND_TOP_NUM:
             {
-                g_touch_uart_rx_num = TOUCH_UART_RECIEVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM;
+                g_touch_uart_rx_num = TOUCH_UART_RECEIVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM;
                 gp_touch_uart_instance->p_api->read(gp_touch_uart_instance->p_ctrl,
                                                     &g_touch_uart_rx_buf[TOUCH_TUNING_COMMAND_BUF_NUM],
                                                     g_touch_uart_rx_num);
@@ -2499,7 +2499,7 @@ void touch_uart_callback (uart_callback_args_t * p_args)
  #if (TOUCH_CFG_UART_TUNING_SUPPORT == 1)
             case TOUCH_TUNING_COMMAND_TOP_NUM:
             {
-                g_touch_uart_rx_num = TOUCH_TUNING_RECIEVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM;
+                g_touch_uart_rx_num = TOUCH_TUNING_RECEIVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM;
                 gp_touch_uart_instance->p_api->read(gp_touch_uart_instance->p_ctrl,
                                                     &g_touch_uart_rx_buf[TOUCH_TUNING_COMMAND_BUF_NUM],
                                                     g_touch_uart_rx_num);
@@ -2524,7 +2524,7 @@ void touch_uart_callback (uart_callback_args_t * p_args)
     }
 
  #if (TOUCH_CFG_MONITOR_ENABLE && (TOUCH_CFG_UART_MONITOR_SUPPORT == 1))
-    if ((g_touch_uart_rx_num == (TOUCH_UART_RECIEVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM)) &&
+    if ((g_touch_uart_rx_num == (TOUCH_UART_RECEIVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM)) &&
         (p_args->event == UART_EVENT_RX_COMPLETE))
     {
         /* Restart reception */
@@ -2806,7 +2806,7 @@ void touch_uart_callback (uart_callback_args_t * p_args)
  #endif
 
  #if (TOUCH_CFG_UART_TUNING_SUPPORT == 1)
-    if ((g_touch_uart_rx_num == (TOUCH_TUNING_RECIEVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM)) &&
+    if ((g_touch_uart_rx_num == (TOUCH_TUNING_RECEIVE_BUF_SIZE - TOUCH_TUNING_COMMAND_BUF_NUM)) &&
         (p_args->event == UART_EVENT_RX_COMPLETE))
     {
         /* Restart reception */
@@ -3306,31 +3306,31 @@ void touch_uart_callback (uart_callback_args_t * p_args)
 
             if (1 == write_byte)
             {
-                port_adress_8 = (uint8_t *) (g_touch_uart_rx_buf[5] |
+                port_address_8 = (uint8_t *) (g_touch_uart_rx_buf[5] |
                                              (g_touch_uart_rx_buf[6] << 8) |
                                              (g_touch_uart_rx_buf[7] << 16) |
                                              (g_touch_uart_rx_buf[8] << 24));
 
-                (*port_adress_8) |= (g_touch_uart_rx_buf[10]);
+                (*port_address_8) |= (g_touch_uart_rx_buf[10]);
             }
             else if (2 == write_byte)
             {
-                port_adress_16 = (uint16_t *) (g_touch_uart_rx_buf[5] |
+                port_address_16 = (uint16_t *) (g_touch_uart_rx_buf[5] |
                                                (g_touch_uart_rx_buf[6] << 8) |
                                                (g_touch_uart_rx_buf[7] << 16) |
                                                (g_touch_uart_rx_buf[8] << 24));
 
-                (*port_adress_16) |= (uint16_t) (g_touch_uart_rx_buf[10] |
+                (*port_address_16) |= (uint16_t) (g_touch_uart_rx_buf[10] |
                                                  (g_touch_uart_rx_buf[11] << 8));
             }
             else
             {
-                port_adress_32 = (uint32_t *) (g_touch_uart_rx_buf[5] |
+                port_address_32 = (uint32_t *) (g_touch_uart_rx_buf[5] |
                                                (g_touch_uart_rx_buf[6] << 8) |
                                                (g_touch_uart_rx_buf[7] << 16) |
                                                (g_touch_uart_rx_buf[8] << 24));
 
-                (*port_adress_32) |= (uint32_t) (g_touch_uart_rx_buf[10] |
+                (*port_address_32) |= (uint32_t) (g_touch_uart_rx_buf[10] |
                                                  (g_touch_uart_rx_buf[11] << 8) |
                                                  (g_touch_uart_rx_buf[12] << 16) |
                                                  (g_touch_uart_rx_buf[13] << 24));
@@ -3344,30 +3344,30 @@ void touch_uart_callback (uart_callback_args_t * p_args)
 
             if (1 == write_byte)
             {
-                port_adress_8 = (uint8_t *) (g_touch_uart_rx_buf[5] |
+                port_address_8 = (uint8_t *) (g_touch_uart_rx_buf[5] |
                                              (g_touch_uart_rx_buf[6] << 8) |
                                              (g_touch_uart_rx_buf[7] << 16) |
                                              (g_touch_uart_rx_buf[8] << 24));
 
-                touch_tuning_send8((*port_adress_8), 6);
+                touch_tuning_send8((*port_address_8), 6);
             }
             else if (2 == write_byte)
             {
-                port_adress_16 = (uint16_t *) (g_touch_uart_rx_buf[5] |
+                port_address_16 = (uint16_t *) (g_touch_uart_rx_buf[5] |
                                                (g_touch_uart_rx_buf[6] << 8) |
                                                (g_touch_uart_rx_buf[7] << 16) |
                                                (g_touch_uart_rx_buf[8] << 24));
 
-                touch_tuning_send16((*port_adress_16), 6);
+                touch_tuning_send16((*port_address_16), 6);
             }
             else
             {
-                port_adress_32 = (uint32_t *) (g_touch_uart_rx_buf[5] |
+                port_address_32 = (uint32_t *) (g_touch_uart_rx_buf[5] |
                                                (g_touch_uart_rx_buf[6] << 8) |
                                                (g_touch_uart_rx_buf[7] << 16) |
                                                (g_touch_uart_rx_buf[8] << 24));
 
-                touch_tuning_send32((*port_adress_32), 6);
+                touch_tuning_send32((*port_address_32), 6);
             }
         }
         else if (g_touch_uart_rx_buf[1] == TOUCH_TUNING_COMMAND_PHASE_RUN)

--- a/ra/fsp/src/rm_tz_context/tz_context.c
+++ b/ra/fsp/src/rm_tz_context/tz_context.c
@@ -217,7 +217,7 @@ uint32_t TZ_StoreContext_S (TZ_MemoryId_t id) {
   __asm volatile (
     "MRS    R1, PSP                          \n" /* r1 = PSP. */
     "VSTMDB R1!, {S0}                        \n" /* Trigger the deferred stacking of FPU registers. */
-    "VLDMIA R1!, {S0}                        \n" /* Nullify the effect of the pervious statement. */
+    "VLDMIA R1!, {S0}                        \n" /* Nullify the effect of the previous statement. */
     ::: "r1", "memory"
   );
 

--- a/ra/fsp/src/rm_usbx_port/rm_usbx_port.c
+++ b/ra/fsp/src/rm_usbx_port/rm_usbx_port.c
@@ -1879,7 +1879,7 @@ static void usb_host_usbx_class_request_cb (usb_utr_t * p_utr, uint16_t data1, u
   #if defined(USB_CFG_HUVC_USE)
     uint32_t             alternate_number;
     uint32_t             interface_number;
-    uint16_t             is_interface_discoverd = 0;
+    uint16_t             is_interface_discovered = 0;
     uint16_t             length;
     uint16_t             offset;
     uint16_t             usb_class;
@@ -2129,12 +2129,12 @@ static void usb_host_usbx_class_request_cb (usb_utr_t * p_utr, uint16_t data1, u
                         if ((UX_HOST_CLASS_VIDEO_SUBCLASS_STREAMING == *(p_config + offset + 6)) &&
                             (alternate_number == *(p_config + offset + 3)))
                         {
-                            is_interface_discoverd = 1;
+                            is_interface_discovered = 1;
                         }
                     }
                 }
 
-                if (1 == is_interface_discoverd)
+                if (1 == is_interface_discovered)
                 {
                     if (USB_DT_ENDPOINT == *(p_config + offset + USB_EP_B_DESCRIPTORTYPE))
                     {
@@ -2650,7 +2650,7 @@ static UINT usb_host_usbx_to_basic (UX_HCD * hcd, UINT function, VOID * paramete
    #if (USB_CFG_DMA == USB_CFG_ENABLE)
                     if (USB_YES == is_in_transfer)
                     {
-                        // IN transfere
+                        // IN transferred
                         max_packet_size = (uint16_t) endpoint->ux_endpoint_descriptor.wMaxPacketSize;
                         if (0 != (size % max_packet_size))
                         {

--- a/ra/fsp/src/rm_vee_flash/rm_vee_flash.c
+++ b/ra/fsp/src/rm_vee_flash/rm_vee_flash.c
@@ -210,7 +210,7 @@ fsp_err_t RM_VEE_FLASH_Open (rm_vee_ctrl_t * const p_api_ctrl, rm_vee_cfg_t cons
     FSP_ERROR_RETURN(RM_VEE_FLASH_OPEN != p_ctrl->open, FSP_ERR_ALREADY_OPEN);
     FSP_ERROR_RETURN(2 <= p_cfg->num_segments, FSP_ERR_INVALID_ARGUMENT);
 
-    /* Start and end adress are valid */
+    /* Start and end address are valid */
     FSP_ERROR_RETURN(BSP_FEATURE_FLASH_DATA_FLASH_START <= p_cfg->start_addr, FSP_ERR_INVALID_ARGUMENT);
     FSP_ERROR_RETURN(RM_VEE_FLASH_PHYSICAL_END_ADDRESS >= (p_cfg->start_addr + p_cfg->total_size),
                      FSP_ERR_INVALID_ARGUMENT);
@@ -1636,7 +1636,7 @@ void rm_vee_flash_callback (flash_callback_args_t * p_args)
                 }
                 else
                 {
-                    /* The end of the record must be written seperately. */
+                    /* The end of the record must be written separately. */
                     length        = length & (~RM_VEE_FLASH_DF_WRITE_MASK);
                     p_ctrl->state = RM_VEE_FLASH_PRV_STATES_WRITE_REC_DATA_TAIL;
                 }

--- a/ra/fsp/src/rm_wifi_onchip_da16xxx/rm_wifi_api_da16xxx.c
+++ b/ra/fsp/src/rm_wifi_onchip_da16xxx/rm_wifi_api_da16xxx.c
@@ -86,7 +86,7 @@ WIFIReturnCode_t WIFI_Off (void)
  *
  * The Wi-Fi should stay connected when the same Access Point it is currently connected to
  * is specified. Otherwise, the Wi-Fi should disconnect and connect to the new Access Point
- * specified. If the new Access Point specifed has invalid parameters, then the Wi-Fi should be
+ * specified. If the new Access Point specified has invalid parameters, then the Wi-Fi should be
  * disconnected.
  *
  * @param[in] pxNetworkParams Configuration to join AP.

--- a/ra/fsp/src/rm_wifi_onchip_da16xxx/rm_wifi_onchip_da16xxx.c
+++ b/ra/fsp/src/rm_wifi_onchip_da16xxx/rm_wifi_onchip_da16xxx.c
@@ -829,7 +829,7 @@ fsp_err_t rm_wifi_onchip_da16xxx_connect (const char   * p_ssid,
     }
     else
     {
-        /* Return with error for unsupported secuirty types */
+        /* Return with error for unsupported security types */
         rm_wifi_onchip_da16xxx_send_basic_give_mutex(p_instance_ctrl, mutex_flag);
 
         return FSP_ERR_WIFI_FAILED;
@@ -1473,7 +1473,7 @@ fsp_err_t rm_wifi_onchip_da16xxx_dns_query (const char * p_textstring, uint8_t *
  * @retval FSP_SUCCESS              Function completed successfully.
  * @retval FSP_ERR_ASSERTION        The parameter p_socket_id is NULL.
  * @retval FSP_ERR_NOT_OPEN         The instance has not been opened.
- * @retval FSP_ERR_WIFI_FAILED      Error occured in the execution of this function
+ * @retval FSP_ERR_WIFI_FAILED      Error occurred in the execution of this function
  **********************************************************************************************************************/
 fsp_err_t rm_wifi_onchip_da16xxx_avail_socket_get (uint32_t * p_socket_id)
 {

--- a/ra/fsp/src/rm_wifi_onchip_silex/rm_wifi_api_silex.c
+++ b/ra/fsp/src/rm_wifi_onchip_silex/rm_wifi_api_silex.c
@@ -84,7 +84,7 @@ WIFIReturnCode_t WIFI_Off (void) {
  *
  * The Wi-Fi should stay connected when the same Access Point it is currently connected to
  * is specified. Otherwise, the Wi-Fi should disconnect and connect to the new Access Point
- * specified. If the new Access Point specifed has invalid parameters, then the Wi-Fi should be
+ * specified. If the new Access Point specified has invalid parameters, then the Wi-Fi should be
  * disconnected.
  *
  * @param[in] pxNetworkParams Configuration to join AP.

--- a/ra/fsp/src/rm_wifi_onchip_silex/rm_wifi_onchip_silex.c
+++ b/ra/fsp/src/rm_wifi_onchip_silex/rm_wifi_onchip_silex.c
@@ -1149,7 +1149,7 @@ fsp_err_t rm_wifi_onchip_silex_connect (const char * p_ssid, WIFISecurity_t secu
     }
     else
     {
-        /* Return with error for unsupported secuirty types */
+        /* Return with error for unsupported security types */
         rm_wifi_onchip_silex_send_basic_give_mutex(p_instance_ctrl, mutex_flag);
 
         return FSP_ERR_WIFI_FAILED;
@@ -1766,7 +1766,7 @@ fsp_err_t rm_wifi_onchip_silex_ip_addr_get (uint32_t * p_ip_addr)
  * @retval FSP_SUCCESS              Function completed successfully.
  * @retval FSP_ERR_ASSERTION        The parameter p_socket_id is NULL.
  * @retval FSP_ERR_NOT_OPEN         The instance has not been opened.
- * @retval FSP_ERR_WIFI_FAILED      Error occured in the execution of this function
+ * @retval FSP_ERR_WIFI_FAILED      Error occurred in the execution of this function
  **********************************************************************************************************************/
 fsp_err_t rm_wifi_onchip_silex_avail_socket_get (uint32_t * p_socket_id)
 {
@@ -2685,7 +2685,7 @@ fsp_err_t rm_wifi_onchip_silex_change_socket (uint32_t socket_no)
 /*******************************************************************************************************************//**
  *  Cancel the current read operation over UART. Return the number of bytes received.
  *
- * @param[in,out]  bytes_received    Location to store number of bytes recieved.
+ * @param[in,out]  bytes_received    Location to store number of bytes received.
  *
  * @retval FSP_SUCCESS              Function completed successfully.
  *
@@ -2707,7 +2707,7 @@ fsp_err_t rm_wifi_onchip_silex_stop_tcp_recv (uint32_t * bytes_received)
 }
 
 /*******************************************************************************************************************//**
- *  Get the recieve start semaphore for the module.
+ *  Get the receive start semaphore for the module.
  *
  * @param[in]  wait_option              How long to wait for the semaphore, this accepts the
  *                                      same values as the wait_option for tx_semaphore_get.
@@ -2721,7 +2721,7 @@ UINT rm_wifi_onchip_silex_get_rx_start_semaphore (ULONG wait_option)
 }
 
 /*******************************************************************************************************************//**
- *  Get the recieve complete (packet filled) semaphore for the module.
+ *  Get the receive complete (packet filled) semaphore for the module.
  *
  * @param[in]  wait_option              How long to wait for the semaphore, this accepts the
  *                                      same values as the wait_option for tx_semaphore_get.
@@ -3197,7 +3197,7 @@ fsp_err_t rm_wifi_onchip_silex_send_basic (wifi_onchip_silex_instance_ctrl_t * p
             if (TX_SUCCESS ==
                 tx_semaphore_get(&p_instance_ctrl->uart_rx_sem[p_instance_ctrl->curr_cmd_port], byte_timeout))
             {
-                /* Next byte recieved */
+                /* Next byte received */
                 recvcnt++;
             }
             else
@@ -3399,7 +3399,7 @@ static fsp_err_t rm_wifi_onchip_silex_send_scan (wifi_onchip_silex_instance_ctrl
         if (TX_SUCCESS ==
             tx_semaphore_get(&p_instance_ctrl->uart_rx_sem[p_instance_ctrl->curr_cmd_port], MS_TO_TICKS(byte_timeout)))
         {
-            /* Next byte recieved */
+            /* Next byte received */
             recvcnt++;
         }
         else
@@ -3681,7 +3681,7 @@ void rm_wifi_onchip_silex_uart_callback (uart_callback_args_t * p_args)
             }
             else
             {
-                /* If we don't have a packet buffer then don't recieve anything */
+                /* If we don't have a packet buffer then don't receive anything */
                 if (NULL == p_instance_ctrl->p_current_packet_buffer)
                 {
                     break;
@@ -3715,13 +3715,13 @@ void rm_wifi_onchip_silex_uart_callback (uart_callback_args_t * p_args)
                 /* Packet buffer has been filled, move to next one */
                 p_instance_ctrl->p_current_packet_buffer = p_instance_ctrl->p_next_packet_buffer;
 
-                /* If we don't have a packet buffer then don't recieve anything */
+                /* If we don't have a packet buffer then don't receive anything */
                 if (NULL == p_instance_ctrl->p_current_packet_buffer)
                 {
                     break;
                 }
 
-                /* Start recieving next packet */
+                /* Start receiving next packet */
                 p_uart_instance->p_api->read(p_uart_instance->p_ctrl,
                                              p_instance_ctrl->p_current_packet_buffer,
                                              p_instance_ctrl->packet_buffer_size);

--- a/ra/tes/dave2d/inc/dave_errorcodes.h
+++ b/ra/tes/dave2d/inc/dave_errorcodes.h
@@ -14,7 +14,7 @@
  * List of all dave driver errorcodes.
  *
  * Every device stores the errorcode returned by the last function executed
- * for this device. Successfull operations reset this code to D2_OK.
+ * for this device. Successful operations reset this code to D2_OK.
  *
  * Latest errorcode can be queried by <d2_geterror> / <d2_geterrorstring> functions
  *

--- a/ra/tes/dave2d/src/dave_64bitoperation.c
+++ b/ra/tes/dave2d/src/dave_64bitoperation.c
@@ -175,7 +175,7 @@ void d2_add64(const d2_int64 *a, const d2_int64 *b, d2_int64 *res)
  *
  *    Function: d2_sub64
  *    
- *    Substraction of 2 64bit value
+ *    Subtraction of 2 64bit value
  *
  *    Parameters:
  *

--- a/ra/tes/dave2d/src/dave_blit.c
+++ b/ra/tes/dave2d/src/dave_blit.c
@@ -243,7 +243,7 @@ d2_s32 d2_setblitsrc( d2_device *handle, void *ptr, d2_s32 pitch, d2_s32 width, 
  * d2_bf_filterv cannot be used if the pitch of the texture is >= 2048
  * 
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_blitcopy( d2_device *handle, d2_s32 srcwidth, d2_s32 srcheight, d2_blitpos srcx, d2_blitpos srcy, d2_width dstwidth, d2_width dstheight, d2_point dstx, d2_point dsty, d2_u32 flags )
 {

--- a/ra/tes/dave2d/src/dave_dlist.c
+++ b/ra/tes/dave2d/src/dave_dlist.c
@@ -57,7 +57,7 @@ static d2_s32 d2_dlist2dlist_intern( d2_device *handle, d2_dlist *dlist, void *a
 
 /*--------------------------------------------------------------------------
  * create a display list block (displaylist memory can be fetched from a
- * different heap, see dave_memory.h for detials)
+ * different heap, see dave_memory.h for details)
  * size specifies the number of dlist entries (4 register slots per entry)
  * */
 d2_dlist_block * d2_alloc_dlistblock_intern( const d2_device *handle, d2_u32 size )
@@ -324,7 +324,7 @@ void d2_nextdlistblock_intern( d2_dlist *dlist )
       d2_insertdlistspecial_intern( dlist, 3 );  /* terminate list correctly */
       /* grow to prepare for next write */
       d2_growdlist_intern( dlist );
-      /* check if d2_growdlist succeded */
+      /* check if d2_growdlist succeeded */
       if ( D2_DEV(dlist->device)->delayed_errorcode != D2_OK )
       {
          /* no more memory -> terminate current list */
@@ -410,7 +410,7 @@ void d2_nextdlistblock_intern( d2_dlist *dlist )
     
       d2_growdlist_intern( dlist );  /* go to next dlist buffer in ring */
 
-      /* check if d2_growdlist succeded */
+      /* check if d2_growdlist succeeded */
       if ( D2_DEV(dlist->device)->delayed_errorcode != D2_OK )
       {
          return;

--- a/ra/tes/dave2d/src/dave_driver.c
+++ b/ra/tes/dave2d/src/dave_driver.c
@@ -17,7 +17,7 @@
  *  2006-11-07 CSe  added dlist_buffer to device struct for 'd2_df_low_localmem' mode
  *  2007-03-01 MGe  added check of null values after creation of renderbuffers
  *  2007-03-12 CSe  fixed error in d2_lowlocalmemmode
- *  2007-05-23 MGe  added null checks in d2_inithw; initalize delayed_errorcode in context
+ *  2007-05-23 MGe  added null checks in d2_inithw; initialize delayed_errorcode in context
  *  2007-08-30 ASc  replaced clib functions, removed tabs, added description for
  *                  d2_getrendermode, changed C++ to C comments, changed g_versionid
  *  2007-09-10 ASc  smaller updates of d2_lowlocalmemmode and d2_inithw
@@ -329,7 +329,7 @@ d2_device * d2_opendevice( d2_u32 flags )
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_closedevice( d2_device *handle )
 {
@@ -457,7 +457,7 @@ const d2_char * d2_geterrorstring( const d2_device *handle )
  *   flags - hardware instance id (use 0 for default)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_inithw( d2_device *handle, d2_u32 flags )
 {
@@ -537,14 +537,14 @@ d2_s32 d2_inithw( d2_device *handle, d2_u32 flags )
 /*--------------------------------------------------------------------------
  * function: d2_deinithw
  * Unlink hardware currently bound by specified device.
- * Hardware must be deinitialized before it can be reinitalized for another
+ * Hardware must be deinitialized before it can be reinitialized for another
  * device.
  *
  * parameters:
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_deinithw( d2_device *handle )
 {
@@ -963,7 +963,7 @@ d2_s32 d2_lowlocalmemmode(d2_device *handle, d2_u32 dlistblockfactor, d2_u32 dli
  *  d2_rm_postprocess - Direct rendering of primitives as a postprocess
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_outlinewidth>, <d2_shadowoffset>
@@ -1051,7 +1051,7 @@ d2_u32 d2_getrendermode( const d2_device *handle )
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_selectrendermode>
@@ -1077,7 +1077,7 @@ d2_s32 d2_layermerge( d2_device *handle )
  *   width - outline width in pixels (fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_selectrendermode>, <d2_shadowoffset>
@@ -1103,7 +1103,7 @@ d2_s32 d2_outlinewidth( d2_device *handle, d2_width width )
  *   y - y axis offset in pixels (fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_selectrendermode>, <d2_outlinewidth>
@@ -1135,7 +1135,7 @@ d2_s32 d2_shadowoffset( d2_device *handle, d2_point x, d2_point y )
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_flushframe( d2_device *handle )
 {

--- a/ra/tes/dave2d/src/dave_intern.h
+++ b/ra/tes/dave2d/src/dave_intern.h
@@ -188,7 +188,7 @@ typedef struct _d2_devicedata
 
    d2_s8   lasttextwasrle;               /* last texture format was RLE */
    d2_s8   maxpatlen;                    /* maximum size of pattern bitvector supported by the hardware */
-   d2_s8   errorcode;                    /* last actions detaild result code */
+   d2_s8   errorcode;                    /* last actions detailed result code */
    d2_s8   delayed_errorcode;            /* errorcondition that exists until the renderbuffer gets executed. This errorcode is used for errors that occure while the scratchbuffer is written to the displaylist */
    d2_s8   hilimiterprecision_supported; /* is set to 1 when the hilimiterprecision feature is supported by the hardware */
 

--- a/ra/tes/dave2d/src/dave_line.c
+++ b/ra/tes/dave2d/src/dave_line.c
@@ -576,7 +576,7 @@ d2_s32 d2_renderline_intern( d2_devicedata *handle, d2_contextdata *ctx, d2_poin
          control = d2_initgradients_intern( handle, ctx, &bbox2, 3, control );
       }
 
-      /* restore seperation limiter to fit new bbox */
+      /* restore separation limiter to fit new bbox */
       if(0 != flip)
       {
          dx = D2_INT4(bbox2.xmin - bbox.xmin);       /* PRQA S 0502 */ /* $Misra: #PERF_ARITHMETIC_SHIFT_RIGHT $*/

--- a/ra/tes/dave2d/src/dave_perfcount.c
+++ b/ra/tes/dave2d/src/dave_perfcount.c
@@ -70,7 +70,7 @@
  *  d2_pc_fbwordswritten - framebuffer cache words written
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_setperfcountevent( d2_device *handle, d2_u32 counter, d2_u32 event )
 {
@@ -129,7 +129,7 @@ d2_s32 d2_setperfcountevent( d2_device *handle, d2_u32 counter, d2_u32 event )
  *   value - value to be set: 0 for reset
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_setperfcountvalue( d2_device *handle, d2_u32 counter, d2_slong value )
 {

--- a/ra/tes/dave2d/src/dave_polyline.c
+++ b/ra/tes/dave2d/src/dave_polyline.c
@@ -72,7 +72,7 @@ d2_s32 d2_renderpolyline_intern( d2_devicedata *handle, d2_contextdata *ctx, con
 
    connectors[0] = connectors[1] = connectors[2] = connectors[3] = 0;
 
-   /* check if linejoins have to be renderd */
+   /* check if linejoins have to be rendered */
    joins = (w > D2_FIX4(1)) ? 1 : 0;
 
    if(count < 3)

--- a/ra/tes/dave2d/src/dave_rbuffer.c
+++ b/ra/tes/dave2d/src/dave_rbuffer.c
@@ -254,7 +254,7 @@ d2_renderbuffer * d2_newrenderbuffer( d2_device *handle, d2_u32 initialsize, d2_
  *   buffer - renderbuffer address
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * */
 d2_s32 d2_freerenderbuffer( d2_device *handle,  d2_renderbuffer *buffer )
@@ -564,7 +564,7 @@ d2_renderbuffer * d2_getrenderbuffer( d2_device *handle, d2_s32 index )
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_startframe( d2_device *handle )
 {
@@ -608,7 +608,7 @@ d2_s32 d2_startframe( d2_device *handle )
  *   handle - device pointer (see: <d2_opendevice>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_endframe( d2_device *handle )
 {
@@ -638,7 +638,7 @@ d2_s32 d2_endframe( d2_device *handle )
  *   ptr - new address of the top left pixel (coordinate 0,0)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * note:
  *   Intention of this function is to support an immediate flush to a hidden
@@ -929,7 +929,7 @@ d2_s32 d2_dumprenderbuffer( d2_device *handle, d2_renderbuffer *buffer, void **r
 
       if(blk == lastBlk)
       {
-         lastEntry = dlist->position;            /* use insert postion of current block */
+         lastEntry = dlist->position;            /* use insert position of current block */
       }
       else
       {
@@ -1150,7 +1150,7 @@ d2_u32 d2_getrenderbuffersize(d2_device *handle, d2_renderbuffer *rb)
  *  data - pointer to memory (created by <d2_dumprenderbuffer>)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_freedumpedbuffer( d2_device *handle, void *data )
 {

--- a/ra/tes/dave2d/src/dave_render.c
+++ b/ra/tes/dave2d/src/dave_render.c
@@ -396,7 +396,7 @@ void d2_startrender_bottom_intern( d2_devicedata *handle, const d2_bbox *bbox, d
  *   color - fill color and alpha
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_clear( d2_device *handle, d2_color color )
 {
@@ -421,7 +421,7 @@ d2_s32 d2_clear( d2_device *handle, d2_color color )
  *   h - height of rectangle in pixels (fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_renderbox( d2_device *handle, d2_point x1, d2_point y1, d2_width w, d2_width h )
 {
@@ -474,7 +474,7 @@ d2_s32 d2_renderbox( d2_device *handle, d2_point x1, d2_point y1, d2_width w, d2
  *   d2_le_exclude_both  - start and endpoint are not part of the line
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_renderline2>, <d2_setlinecap>
@@ -533,7 +533,7 @@ d2_s32 d2_renderline( d2_device *handle, d2_point x1, d2_point y1, d2_point x2, 
  *   d2_le_exclude_both  - start and endpoint are not part of the line
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_renderline>, <d2_setlinecap>
@@ -586,7 +586,7 @@ d2_s32 d2_renderline2(  d2_device *handle, d2_point x1, d2_point y1, d2_point x2
  * d2_edge2_shared - edge from (x3,y3) - (x1,y1) is shared
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_rendertri( d2_device *handle, d2_point x1, d2_point y1, d2_point x2, d2_point y2, d2_point x3, d2_point y3, d2_u32 flags )
 {
@@ -639,7 +639,7 @@ d2_s32 d2_rendertri( d2_device *handle, d2_point x1, d2_point y1, d2_point x2, d
  * d2_edge3_shared - edge from (x4,y4) - (x1,y1) is shared
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_renderquad( d2_device *handle, d2_point x1, d2_point y1, d2_point x2, d2_point y2, d2_point x3, d2_point y3, d2_point x4, d2_point y4, d2_u32 flags )
 {
@@ -684,7 +684,7 @@ d2_s32 d2_renderquad( d2_device *handle, d2_point x1, d2_point y1, d2_point x2, 
  *   w - width or 0 for a solid circle (fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_rendercircle( d2_device *handle, d2_point x, d2_point y, d2_width r, d2_width w )
 {
@@ -832,7 +832,7 @@ d2_s32 d2_renderwedge( d2_device *handle, d2_point x, d2_point y, d2_width r, d2
  *   d2_le_closed - polyline has no start or endpoint, last vertex is connected back to first
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_setlinecap>, <d2_setlinejoin>
@@ -889,7 +889,7 @@ d2_s32 d2_renderpolyline( d2_device *handle, const d2_point *data, d2_u32 count,
  *   d2_le_closed - polyline has no start or endpoint, last vertex is connected back to first
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_setlinecap>, <d2_setlinejoin>, <d2_renderpolyline>
@@ -945,7 +945,7 @@ d2_s32 d2_renderpolyline2( d2_device *handle, const d2_point *data, d2_u32 count
  *   count - number of triangles
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *  <d2_rendertri>, <d2_rendertrifan>, <d2_rendertristrip>
@@ -1015,7 +1015,7 @@ d2_s32 d2_rendertrilist( d2_device *handle, const d2_point *data, const d2_u32 *
  *   count - number of triangles
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *  <d2_rendertri>, <d2_rendertrifan>, <d2_rendertrilist>
@@ -1133,7 +1133,7 @@ d2_s32 d2_rendertristrip( d2_device *handle, const d2_point *data, const d2_u32 
  *   count - number of triangles
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *  <d2_rendertri>, <d2_rendertrilist>, <d2_rendertristrip>
@@ -1182,7 +1182,7 @@ d2_s32 d2_rendertrifan( d2_device *handle, const d2_point *data, const d2_u32 *f
 /* function: d2_renderpolygon
  * Render a convex polygon
  *
- * All vertices have to be in clockwise order. If seperation into monoton
+ * All vertices have to be in clockwise order. If separation into monoton
  * subregions is required, internal edges will be flagged as 'shared'
  * automatically.
  * Outer edges are always nonshared for now.
@@ -1195,7 +1195,7 @@ d2_s32 d2_rendertrifan( d2_device *handle, const d2_point *data, const d2_u32 *f
  *   flags - reserved (should be NULL)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_renderpolygon( d2_device *handle, const d2_point *data, d2_u32 count, d2_u32 flags)
 {

--- a/ra/tes/dave2d/src/dave_texture.c
+++ b/ra/tes/dave2d/src/dave_texture.c
@@ -336,7 +336,7 @@ d2_s32 d2_settexture( d2_device *handle, void *ptr, d2_s32 pitch, d2_s32 width, 
  *  d2_tm_filter - apply bilinear filter (both axis)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_settexturemode( d2_device *handle, d2_u32 mode )
 {
@@ -380,7 +380,7 @@ d2_s32 d2_settexturemode( d2_device *handle, d2_u32 mode )
  * function: d2_settextureoperation
  * Choose texture operation for each channel.
  *
- * Textures can be 'colorized' by a varity of operations. A textureoperation
+ * Textures can be 'colorized' by a variety of operations. A textureoperation
  * can be defined for each channel (a,r,g,b) individually.
  * Depending on the chosen operation one or two additional parameters
  * have to be set using <d2_settexopparam>.
@@ -406,7 +406,7 @@ d2_s32 d2_settexturemode( d2_device *handle, d2_u32 mode )
  *   d2_to_blend - use channel data to blend between two constants (p1,p2)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_settexopparam>
@@ -470,7 +470,7 @@ d2_s32 d2_settextureoperation( d2_device *handle, d2_u8 amode, d2_u8 rmode, d2_u
  *   d2_cc_all - all channels
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *   <d2_settextureoperation>
@@ -553,7 +553,7 @@ d2_s32 d2_settexopparam( d2_device *handle, d2_u32 index, d2_u32 p1, d2_u32 p2 )
  *   dyu, dyv - texture increment for a step in y direction (16:16 fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_settexturemapping( d2_device *handle, d2_point x, d2_point y, d2_s32 u0, d2_s32 v0, d2_s32 dxu, d2_s32 dyu, d2_s32 dxv, d2_s32 dyv )
 {
@@ -589,7 +589,7 @@ d2_s32 d2_settexturemapping( d2_device *handle, d2_point x, d2_point y, d2_s32 u
  *   x , y - subpixel position of the texel center (fixedpoint)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_settexelcenter( d2_device *handle, d2_point x, d2_point y )
 {
@@ -958,7 +958,7 @@ d2_s32 d2_settexclut_format( d2_device *handle, d2_u32 format )
  *   color_key  - RGB value of color key 
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * note:
  *   colorkeying is available if the feature bit D2FB_COLORKEY is set (see <d2_getrevisionhw>)

--- a/ra/tes/dave2d/src/dave_utility.c
+++ b/ra/tes/dave2d/src/dave_utility.c
@@ -44,7 +44,7 @@
  * and is overwriting the current values.
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * see also:
  *  <d2_settexturemapping> */
@@ -239,7 +239,7 @@ d2_s32 d2_utility_maptriangle( d2_device *handle, const d2_f32 *points, const d2
  *   wt - 1/z (z>1) value in 16 Bit fraction (z=2 -> wt=65536/2)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * example:
  * Copy a 256x256 source texture into a 640x480 destination rectangle:

--- a/ra/tes/dave2d/src/dave_viewport.c
+++ b/ra/tes/dave2d/src/dave_viewport.c
@@ -52,7 +52,7 @@
  *   ymax - integer pixel position of bottom border (inclusive)
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_cliprect( d2_device *handle, d2_border xmin, d2_border ymin, d2_border xmax, d2_border ymax )
 {
@@ -126,7 +126,7 @@ d2_s32 d2_cliprect( d2_device *handle, d2_border xmin, d2_border ymin, d2_border
  *   ymax - pointer to an integer that receives pixel position of bottom border
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_getcliprect( d2_device *handle, d2_border *xmin, d2_border *ymin, d2_border *xmax, d2_border *ymax )
 {
@@ -188,7 +188,7 @@ d2_s32 d2_getcliprect( d2_device *handle, d2_border *xmin, d2_border *ymin, d2_b
  *  d2_mode_rgba4444 - colored 16bit per pixel
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  *
  * note:
  *   this function has no effect on what memory area is currently visible
@@ -295,7 +295,7 @@ d2_s32 d2_framebuffer( d2_device *handle, void *ptr, d2_s32 pitch, d2_u32 width,
  *  d2_mode_argb4444 - colored 16bit per pixel
  *
  * returns:
- *   errorcode (D2_OK if successfull) see list of <Errorcodes> for details
+ *   errorcode (D2_OK if successful) see list of <Errorcodes> for details
  * */
 d2_s32 d2_getframebuffer( d2_device *handle, void** ptr, d2_s32 * pitch, d2_u32 * width, d2_u32 * height, d2_s32 * format )
 {


### PR DESCRIPTION
Fix all currently found issues with misspell.
```
misspell -i mosquitto -w .
```

Add GitHub action to run it for every PR.
- This takes less than a minute per PR.
- You get lots of free minutes in the enterprise account (50 000) and a few hundred even with the free accounts.

Some code changes in there, I suppose as long as those are for internal (non-public) interfaces/APIs only - they should not matter. But I can't confirm that 100% on my own. Two choices:
- take fix in, publish migration guide in next release.
    - Migration should be as easy as running `misspell -i mosquitto -w .` in the users's codebase as well.
    - Same fixes will be applied.
- Ignore change - change misspell action to be different (do not allow MORE new findings rather than aim for 100% clean run).

Please review @renesas-fsp-development team.
