### PR TITLE
Bugfix: Disable the hardware TRNG before stopping the module clock to it to prevent excessive current draw in power down.

### DIFF
--- a/ra/fsp/src/r_sce/common/hw_sce_common.h
+++ b/ra/fsp/src/r_sce/common/hw_sce_common.h
@@ -76,6 +76,10 @@ __STATIC_INLINE void HW_SCE_PowerOff (void)
 {
 #if BSP_FEATURE_TRNG_HAS_MODULE_STOP
 
+    // Disable hardware TRNG before module stop.
+    // Note: Must perform this step BEFORE TRNG module stop, or the TRNG hardware will draw excessive current in power off.
+    R_TRNG->TRNGSCR0_b.SGCEN = 0;
+
     // RA2 MCU series has separate power control for RNG
     R_MSTP->MSTPCRC_b.MSTPC28 = 1;
 #endif


### PR DESCRIPTION
### Problem Description
The FSP code that powers down the SCE / TRNG module in the 'HW_SCE_PowerOff' function does not disable the hardware random number generator (TRNG) before stopping the module clock to it.  This can leave the TRNG enabled and drawing an additional 370uA (as measured with a Joulescope in our application) when powered down.  Note that the TRNG is only enabled and made active by the FSP if BOTH of the following occur: 
1) Call 'HW_SCE_PowerOn' (or the higher level 'HW_SCE_McuSpecificInit') to enable the module clock to the TRNG.
2) Make at least 1 call to 'HW_SCE_RNG_Read' (which sets the R_TRNG->TRNGSCR0_b.SGCEN bit).

After these steps, calling 'HW_SCE_PowerOff' to power down the SCE and TRNG leaves the TRNG enabled when the module clock is stopped.  This causes the microcontroller to consume an additional 370uA continuously.  

### Fix
The fix is to disable the TRNG in 'HW_SCE_PowerOff' BEFORE the module clock is stopped.

### Post-Fix Observations
Testing with the Joulescope after the fix reveals that the microcontroller no longer draws the extra 370uA after 'HW_SCE_PowerOff' is called.


Closes  #329