### PR TITLE
Fix NameError by initializing message_str

### DIFF
--- a/ra/fsp/src/rm_mcuboot_port/rm_mcuboot_port_sign.py
+++ b/ra/fsp/src/rm_mcuboot_port/rm_mcuboot_port_sign.py
@@ -6,6 +6,9 @@ import sys
 # Determine root of bootloader project to find related files
 boot_project_root = os.path.abspath(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../..'))
 
+# Initialize an empty string for the message
+message_str = ""
+
 # Make sure python3 is used
 if not sys.version_info >= (3, 3):
     print("ERROR: The MCUboot signing script requires version Python version 3.3 or later. The python command can be modified in the MCUboot properties. Current Python version used is:\n" + sys.version)


### PR DESCRIPTION
Fix NameError by initializing message_str  
  
The script was failing with a NameError due to the use of an uninitialized variable `message_str`. This occurs when none of the conditions for setting `message_str` are met, leading to a scenario where the variable is referenced before assignment.  
  
To prevent this error and ensure that `message_str` is always defined, I have added an initialization of `message_str` to an empty string at the beginning of the script.  

This change ensures that the script can run without encountering a NameError, even if the conditions for setting `message_str` are not met.